### PR TITLE
Add setting display nonce

### DIFF
--- a/src/handle_swap_sign_transaction.c
+++ b/src/handle_swap_sign_transaction.c
@@ -60,6 +60,7 @@ void handle_swap_sign_transaction(chain_config_t* config) {
         storage.dataAllowed = 0x00;
         storage.contractDetails = 0x00;
         storage.initialized = 0x01;
+        storage.displayNonce = 0x00;
         nvm_write((void*) &N_storage, (void*) &storage, sizeof(internalStorage_t));
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -714,6 +714,7 @@ void coin_main(chain_config_t *coin_config) {
                     internalStorage_t storage;
                     storage.dataAllowed = 0x00;
                     storage.contractDetails = 0x00;
+                    storage.displayNonce = 0x00;
                     storage.initialized = 0x01;
                     nvm_write((void *) &N_storage, (void *) &storage, sizeof(internalStorage_t));
                 }

--- a/src/shared_context.h
+++ b/src/shared_context.h
@@ -158,7 +158,7 @@ typedef struct txStringProperties_t {
     char fullAddress[43];
     char fullAmount[50];
     char maxFee[50];
-    char nonce[14];  // size needed to write "NOT Displayed"
+    char nonce[8];  // 10M tx per account ought to be enough for everybody
 } txStringProperties_t;
 
 typedef struct strDataTmp_t {

--- a/src/shared_context.h
+++ b/src/shared_context.h
@@ -158,7 +158,7 @@ typedef struct txStringProperties_t {
     char fullAddress[43];
     char fullAmount[50];
     char maxFee[50];
-    char nonce[14]; // size needed to write "NOT Displayed"
+    char nonce[14];  // size needed to write "NOT Displayed"
 } txStringProperties_t;
 
 typedef struct strDataTmp_t {

--- a/src/shared_context.h
+++ b/src/shared_context.h
@@ -27,6 +27,7 @@
 typedef struct internalStorage_t {
     unsigned char dataAllowed;
     unsigned char contractDetails;
+    unsigned char displayNonce;
     uint8_t initialized;
 } internalStorage_t;
 
@@ -157,6 +158,7 @@ typedef struct txStringProperties_t {
     char fullAddress[43];
     char fullAmount[50];
     char maxFee[50];
+    char nonce[14]; // size needed to write "NOT Displayed"
 } txStringProperties_t;
 
 typedef struct strDataTmp_t {

--- a/src/ui_flow.c
+++ b/src/ui_flow.c
@@ -134,9 +134,8 @@ UX_FLOW(ux_settings_flow,
 void display_settings() {
     strcpy(strings.common.fullAddress, (N_storage.dataAllowed ? "Allowed" : "NOT Allowed"));
     strcpy(strings.common.fullAddress + 20,
-            (N_storage.contractDetails ? "Displayed" : "NOT Displayed"));
-    strcpy(strings.common.nonce,
-            (N_storage.displayNonce ? "Displayed" : "NOT Displayed"));
+           (N_storage.contractDetails ? "Displayed" : "NOT Displayed"));
+    strcpy(strings.common.nonce, (N_storage.displayNonce ? "Displayed" : "NOT Displayed"));
     ux_flow_init(0, ux_settings_flow, NULL);
 }
 

--- a/src/ui_flow.c
+++ b/src/ui_flow.c
@@ -4,6 +4,7 @@
 void display_settings(void);
 void switch_settings_contract_data(void);
 void switch_settings_display_data(void);
+void switch_settings_display_nonce(void);
 
 //////////////////////////////////////////////////////////////////////
 // clang-format off
@@ -68,6 +69,15 @@ UX_STEP_CB(
       .text = strings.common.fullAddress + 20
     });
 
+UX_STEP_CB(
+    ux_settings_flow_3_step,
+    bnnn_paging,
+    switch_settings_display_nonce(),
+    {
+      .title = "Account nonce",
+      .text = strings.common.nonce
+    });
+
 #else
 
 UX_STEP_CB(
@@ -91,11 +101,22 @@ UX_STEP_CB(
       "details",
       strings.common.fullAddress + 20
     });
+  
+  UX_STEP_CB(
+    ux_settings_flow_3_step,
+    bnnn,
+    switch_settings_display_nonce(),
+    {
+      "Nonce",
+      "Display account nonce",
+      "details",
+      strings.common.nonce
+    });
 
 #endif
 
 UX_STEP_CB(
-    ux_settings_flow_3_step,
+    ux_settings_flow_4_step,
     pb,
     ui_idle(),
     {
@@ -107,12 +128,15 @@ UX_STEP_CB(
 UX_FLOW(ux_settings_flow,
         &ux_settings_flow_1_step,
         &ux_settings_flow_2_step,
-        &ux_settings_flow_3_step);
+        &ux_settings_flow_3_step,
+        &ux_settings_flow_4_step);
 
 void display_settings() {
     strcpy(strings.common.fullAddress, (N_storage.dataAllowed ? "Allowed" : "NOT Allowed"));
     strcpy(strings.common.fullAddress + 20,
-           (N_storage.contractDetails ? "Displayed" : "NOT Displayed"));
+            (N_storage.contractDetails ? "Displayed" : "NOT Displayed"));
+    strcpy(strings.common.nonce,
+            (N_storage.displayNonce ? "Displayed" : "NOT Displayed"));
     ux_flow_init(0, ux_settings_flow, NULL);
 }
 
@@ -125,5 +149,11 @@ void switch_settings_contract_data() {
 void switch_settings_display_data() {
     uint8_t value = (N_storage.contractDetails ? 0 : 1);
     nvm_write((void*) &N_storage.contractDetails, (void*) &value, sizeof(uint8_t));
+    display_settings();
+}
+
+void switch_settings_display_nonce() {
+    uint8_t value = (N_storage.displayNonce ? 0 : 1);
+    nvm_write((void*) &N_storage.displayNonce, (void*) &value, sizeof(uint8_t));
     display_settings();
 }

--- a/src/ui_flow.c
+++ b/src/ui_flow.c
@@ -1,7 +1,7 @@
 #include "shared_context.h"
 #include "ui_callbacks.h"
 
-void display_settings(void);
+void display_settings(const ux_flow_step_t* const start_step);
 void switch_settings_contract_data(void);
 void switch_settings_display_data(void);
 void switch_settings_display_nonce(void);
@@ -26,7 +26,7 @@ UX_STEP_NOCB(
 UX_STEP_CB(
     ux_idle_flow_3_step,
     pb,
-    display_settings(),
+    display_settings(NULL),
     {
       &C_icon_eye,
       "Settings",
@@ -66,7 +66,7 @@ UX_STEP_CB(
     switch_settings_display_data(),
     {
       .title = "Debug data",
-      .text = strings.common.fullAddress + 20
+      .text = strings.common.fullAddress + 12
     });
 
 UX_STEP_CB(
@@ -75,7 +75,7 @@ UX_STEP_CB(
     switch_settings_display_nonce(),
     {
       .title = "Account nonce",
-      .text = strings.common.nonce
+      .text = strings.common.fullAddress + 26
     });
 
 #else
@@ -99,9 +99,9 @@ UX_STEP_CB(
       "Debug data",
       "Display contract data",
       "details",
-      strings.common.fullAddress + 20
+      strings.common.fullAddress + 12
     });
-  
+
   UX_STEP_CB(
     ux_settings_flow_3_step,
     bnnn,
@@ -109,8 +109,8 @@ UX_STEP_CB(
     {
       "Nonce",
       "Display account nonce",
-      "details",
-      strings.common.nonce
+      "in transactions",
+      strings.common.fullAddress + 26
     });
 
 #endif
@@ -131,28 +131,29 @@ UX_FLOW(ux_settings_flow,
         &ux_settings_flow_3_step,
         &ux_settings_flow_4_step);
 
-void display_settings() {
+void display_settings(const ux_flow_step_t* const start_step) {
     strcpy(strings.common.fullAddress, (N_storage.dataAllowed ? "Allowed" : "NOT Allowed"));
-    strcpy(strings.common.fullAddress + 20,
+    strcpy(strings.common.fullAddress + 12,
            (N_storage.contractDetails ? "Displayed" : "NOT Displayed"));
-    strcpy(strings.common.nonce, (N_storage.displayNonce ? "Displayed" : "NOT Displayed"));
-    ux_flow_init(0, ux_settings_flow, NULL);
+    strcpy(strings.common.fullAddress + 26,
+           (N_storage.displayNonce ? "Displayed" : "NOT Displayed"));
+    ux_flow_init(0, ux_settings_flow, start_step);
 }
 
 void switch_settings_contract_data() {
     uint8_t value = (N_storage.dataAllowed ? 0 : 1);
     nvm_write((void*) &N_storage.dataAllowed, (void*) &value, sizeof(uint8_t));
-    display_settings();
+    display_settings(&ux_settings_flow_1_step);
 }
 
 void switch_settings_display_data() {
     uint8_t value = (N_storage.contractDetails ? 0 : 1);
     nvm_write((void*) &N_storage.contractDetails, (void*) &value, sizeof(uint8_t));
-    display_settings();
+    display_settings(&ux_settings_flow_2_step);
 }
 
 void switch_settings_display_nonce() {
     uint8_t value = (N_storage.displayNonce ? 0 : 1);
     nvm_write((void*) &N_storage.displayNonce, (void*) &value, sizeof(uint8_t));
-    display_settings();
+    display_settings(&ux_settings_flow_3_step);
 }

--- a/src/ui_flow.h
+++ b/src/ui_flow.h
@@ -12,10 +12,6 @@ extern const ux_flow_step_t* const ux_confirm_selector_flow[];
 
 extern const ux_flow_step_t* const ux_confirm_parameter_flow[];
 
-extern const ux_flow_step_t* const ux_approval_tx_flow[];
-
-extern const ux_flow_step_t* const ux_approval_tx_data_warning_flow[];
-
 extern const ux_flow_step_t* const ux_approval_allowance_flow[];
 
 extern const ux_flow_step_t* const ux_sign_flow[];

--- a/src_common/ethUstream.c
+++ b/src_common/ethUstream.c
@@ -117,9 +117,10 @@ static void processNonce(txContext_t *context) {
     if (context->currentFieldPos < context->currentFieldLength) {
         uint32_t copySize =
             MIN(context->commandLength, context->currentFieldLength - context->currentFieldPos);
-        copyTxData(context, NULL, copySize);
+        copyTxData(context, context->content->nonce.value, copySize);
     }
     if (context->currentFieldPos == context->currentFieldLength) {
+        context->content->nonce.length = context->currentFieldLength;
         context->currentField++;
         context->processingField = false;
     }

--- a/src_common/ethUstream.h
+++ b/src_common/ethUstream.h
@@ -69,6 +69,7 @@ typedef struct txContent_t {
     txInt256_t gasprice;
     txInt256_t startgas;
     txInt256_t value;
+    txInt256_t nonce;
     uint8_t destination[20];
     uint8_t destinationLength;
     uint8_t v[4];

--- a/src_features/signTx/logic_signTx.c
+++ b/src_features/signTx/logic_signTx.c
@@ -229,7 +229,7 @@ void computeFees(char *displayBuffer, uint32_t displayBufferSize) {
 }
 
 void finalizeParsing(bool direct) {
-    char displayBuffer[50];
+    char displayBuffer[79]; // required to store the string representation of uint256_t max
     uint8_t decimals = WEI_TO_ETHER;
     uint8_t *ticker = (uint8_t *) PIC(chainConfig->coinName);
     ethPluginFinalize_t pluginFinalize;
@@ -352,6 +352,15 @@ void finalizeParsing(bool direct) {
                        displayBuffer,
                        sizeof(displayBuffer));
         compareOrCopy(strings.common.fullAmount, displayBuffer, called_from_swap);
+    }
+    // Prepare nonce to display
+    if (genericUI) {
+        uint256_t nonce;
+        convertUint256BE(tmpContent.txContent.nonce.value,
+                         tmpContent.txContent.nonce.length,
+                         &nonce);
+        tostring256(&nonce, 10, displayBuffer, sizeof(displayBuffer));
+        compareOrCopy(strings.common.nonce, displayBuffer, called_from_swap);
     }
     // Compute maximum fee
     if (genericUI) {

--- a/src_features/signTx/logic_signTx.c
+++ b/src_features/signTx/logic_signTx.c
@@ -229,7 +229,7 @@ void computeFees(char *displayBuffer, uint32_t displayBufferSize) {
 }
 
 void finalizeParsing(bool direct) {
-    char displayBuffer[79]; // required to store the string representation of uint256_t max
+    char displayBuffer[79];  // required to store the string representation of uint256_t max
     uint8_t decimals = WEI_TO_ETHER;
     uint8_t *ticker = (uint8_t *) PIC(chainConfig->coinName);
     ethPluginFinalize_t pluginFinalize;

--- a/src_features/signTx/logic_signTx.c
+++ b/src_features/signTx/logic_signTx.c
@@ -380,11 +380,7 @@ void finalizeParsing(bool direct) {
         io_seproxyhal_touch_tx_ok(NULL);
     } else {
         if (genericUI) {
-            ux_flow_init(
-                0,
-                ((dataPresent && !N_storage.contractDetails) ? ux_approval_tx_data_warning_flow
-                                                             : ux_approval_tx_flow),
-                NULL);
+            ux_approve_tx(dataPresent);
         } else {
             plugin_ui_start();
         }

--- a/src_features/signTx/logic_signTx.c
+++ b/src_features/signTx/logic_signTx.c
@@ -229,7 +229,7 @@ void computeFees(char *displayBuffer, uint32_t displayBufferSize) {
 }
 
 void finalizeParsing(bool direct) {
-    char displayBuffer[79];  // required to store the string representation of uint256_t max
+    char displayBuffer[50];
     uint8_t decimals = WEI_TO_ETHER;
     uint8_t *ticker = (uint8_t *) PIC(chainConfig->coinName);
     ethPluginFinalize_t pluginFinalize;

--- a/src_features/signTx/logic_signTx.c
+++ b/src_features/signTx/logic_signTx.c
@@ -360,7 +360,7 @@ void finalizeParsing(bool direct) {
                          tmpContent.txContent.nonce.length,
                          &nonce);
         tostring256(&nonce, 10, displayBuffer, sizeof(displayBuffer));
-        compareOrCopy(strings.common.nonce, displayBuffer, called_from_swap);
+        strncpy(strings.common.nonce, displayBuffer, sizeof(strings.common.nonce));
     }
     // Compute maximum fee
     if (genericUI) {

--- a/src_features/signTx/ui_flow_signTx.c
+++ b/src_features/signTx/ui_flow_signTx.c
@@ -148,23 +148,23 @@ UX_STEP_NOCB(ux_approval_tx_data_warning_step,
     });
 // clang-format on
 
-const ux_flow_step_t *ux_approval_tx_flow_scott[9];
+const ux_flow_step_t *ux_approval_tx_flow_[9];
 
 void ux_approve_tx(bool dataPresent) {
     int step = 0;
-    ux_approval_tx_flow_scott[step++] = &ux_approval_tx_1_step;
+    ux_approval_tx_flow_[step++] = &ux_approval_tx_1_step;
     if (dataPresent && !N_storage.contractDetails) {
-        ux_approval_tx_flow_scott[step++] = &ux_approval_tx_data_warning_step;
+        ux_approval_tx_flow_[step++] = &ux_approval_tx_data_warning_step;
     }
-    ux_approval_tx_flow_scott[step++] = &ux_approval_tx_2_step;
-    ux_approval_tx_flow_scott[step++] = &ux_approval_tx_3_step;
+    ux_approval_tx_flow_[step++] = &ux_approval_tx_2_step;
+    ux_approval_tx_flow_[step++] = &ux_approval_tx_3_step;
     if (N_storage.displayNonce) {
-        ux_approval_tx_flow_scott[step++] = &ux_approval_tx_display_nonce_step;
+        ux_approval_tx_flow_[step++] = &ux_approval_tx_display_nonce_step;
     }
-    ux_approval_tx_flow_scott[step++] = &ux_approval_tx_4_step;
-    ux_approval_tx_flow_scott[step++] = &ux_approval_tx_5_step;
-    ux_approval_tx_flow_scott[step++] = &ux_approval_tx_6_step;
-    ux_approval_tx_flow_scott[step++] = FLOW_END_STEP;
+    ux_approval_tx_flow_[step++] = &ux_approval_tx_4_step;
+    ux_approval_tx_flow_[step++] = &ux_approval_tx_5_step;
+    ux_approval_tx_flow_[step++] = &ux_approval_tx_6_step;
+    ux_approval_tx_flow_[step++] = FLOW_END_STEP;
 
-    ux_flow_init(0, ux_approval_tx_flow_scott, NULL);
+    ux_flow_init(0, ux_approval_tx_flow_, NULL);
 }

--- a/src_features/signTx/ui_flow_signTx.c
+++ b/src_features/signTx/ui_flow_signTx.c
@@ -131,6 +131,14 @@ UX_STEP_CB(
       "Reject",
     });
 
+UX_STEP_NOCB(
+    ux_approval_tx_display_nonce_step,
+    bnnn_paging,
+    {
+      .title = "Nonce",
+      .text = strings.common.nonce,
+    });
+
 UX_STEP_NOCB(ux_approval_tx_data_warning_step,
     pbb,
     {
@@ -144,6 +152,7 @@ UX_FLOW(ux_approval_tx_flow,
         &ux_approval_tx_1_step,
         &ux_approval_tx_2_step,
         &ux_approval_tx_3_step,
+        &ux_approval_tx_display_nonce_step,
         &ux_approval_tx_4_step,
         &ux_approval_tx_5_step,
         &ux_approval_tx_6_step);
@@ -153,6 +162,7 @@ UX_FLOW(ux_approval_tx_data_warning_flow,
         &ux_approval_tx_data_warning_step,
         &ux_approval_tx_2_step,
         &ux_approval_tx_3_step,
+        &ux_approval_tx_display_nonce_step,
         &ux_approval_tx_4_step,
         &ux_approval_tx_5_step,
         &ux_approval_tx_6_step);

--- a/src_features/signTx/ui_flow_signTx.c
+++ b/src_features/signTx/ui_flow_signTx.c
@@ -151,20 +151,20 @@ UX_STEP_NOCB(ux_approval_tx_data_warning_step,
 const ux_flow_step_t *ux_approval_tx_flow_scott[9];
 
 void ux_approve_tx(bool dataPresent) {
-  int step = 0;
-  ux_approval_tx_flow_scott[step++] = &ux_approval_tx_1_step;
-  if (dataPresent && !N_storage.contractDetails) {
-    ux_approval_tx_flow_scott[step++] = &ux_approval_tx_data_warning_step;
-  }
-  ux_approval_tx_flow_scott[step++] = &ux_approval_tx_2_step;
-  ux_approval_tx_flow_scott[step++] = &ux_approval_tx_3_step;
-  if (N_storage.displayNonce) {
-    ux_approval_tx_flow_scott[step++] = &ux_approval_tx_display_nonce_step;
-  }
-  ux_approval_tx_flow_scott[step++] = &ux_approval_tx_4_step;
-  ux_approval_tx_flow_scott[step++] = &ux_approval_tx_5_step;
-  ux_approval_tx_flow_scott[step++] = &ux_approval_tx_6_step;
-  ux_approval_tx_flow_scott[step++] = FLOW_END_STEP;
+    int step = 0;
+    ux_approval_tx_flow_scott[step++] = &ux_approval_tx_1_step;
+    if (dataPresent && !N_storage.contractDetails) {
+        ux_approval_tx_flow_scott[step++] = &ux_approval_tx_data_warning_step;
+    }
+    ux_approval_tx_flow_scott[step++] = &ux_approval_tx_2_step;
+    ux_approval_tx_flow_scott[step++] = &ux_approval_tx_3_step;
+    if (N_storage.displayNonce) {
+        ux_approval_tx_flow_scott[step++] = &ux_approval_tx_display_nonce_step;
+    }
+    ux_approval_tx_flow_scott[step++] = &ux_approval_tx_4_step;
+    ux_approval_tx_flow_scott[step++] = &ux_approval_tx_5_step;
+    ux_approval_tx_flow_scott[step++] = &ux_approval_tx_6_step;
+    ux_approval_tx_flow_scott[step++] = FLOW_END_STEP;
 
-  ux_flow_init(0, ux_approval_tx_flow_scott, NULL);
+    ux_flow_init(0, ux_approval_tx_flow_scott, NULL);
 }

--- a/src_features/signTx/ui_flow_signTx.c
+++ b/src_features/signTx/ui_flow_signTx.c
@@ -148,21 +148,23 @@ UX_STEP_NOCB(ux_approval_tx_data_warning_step,
     });
 // clang-format on
 
-UX_FLOW(ux_approval_tx_flow,
-        &ux_approval_tx_1_step,
-        &ux_approval_tx_2_step,
-        &ux_approval_tx_3_step,
-        &ux_approval_tx_display_nonce_step,
-        &ux_approval_tx_4_step,
-        &ux_approval_tx_5_step,
-        &ux_approval_tx_6_step);
+const ux_flow_step_t *ux_approval_tx_flow_scott[9];
 
-UX_FLOW(ux_approval_tx_data_warning_flow,
-        &ux_approval_tx_1_step,
-        &ux_approval_tx_data_warning_step,
-        &ux_approval_tx_2_step,
-        &ux_approval_tx_3_step,
-        &ux_approval_tx_display_nonce_step,
-        &ux_approval_tx_4_step,
-        &ux_approval_tx_5_step,
-        &ux_approval_tx_6_step);
+void ux_approve_tx(bool dataPresent) {
+  int step = 0;
+  ux_approval_tx_flow_scott[step++] = &ux_approval_tx_1_step;
+  if (dataPresent && !N_storage.contractDetails) {
+    ux_approval_tx_flow_scott[step++] = &ux_approval_tx_data_warning_step;
+  }
+  ux_approval_tx_flow_scott[step++] = &ux_approval_tx_2_step;
+  ux_approval_tx_flow_scott[step++] = &ux_approval_tx_3_step;
+  if (N_storage.displayNonce) {
+    ux_approval_tx_flow_scott[step++] = &ux_approval_tx_display_nonce_step;
+  }
+  ux_approval_tx_flow_scott[step++] = &ux_approval_tx_4_step;
+  ux_approval_tx_flow_scott[step++] = &ux_approval_tx_5_step;
+  ux_approval_tx_flow_scott[step++] = &ux_approval_tx_6_step;
+  ux_approval_tx_flow_scott[step++] = FLOW_END_STEP;
+
+  ux_flow_init(0, ux_approval_tx_flow_scott, NULL);
+}


### PR DESCRIPTION
This PR aims at adding a special setting to be able to display the nonce when approving a transaction.
The setting is off by default.

Additionally, this PR reworks how the UX_FLOW array was constructed, making it dynamic (this will help if we wish to add additional settings).