### PR TITLE
Support EIP2718 (transaction types) and EIP2930 (access list transactions) and display ChainID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,13 @@ else
 DEFINES   += IO_SEPROXYHAL_BUFFER_SIZE_B=72
 endif
 
+# Enables direct data signing without having to specify it in the settings. Useful when testing with speculos.
+ALLOW_DATA:=0
+ifneq ($(ALLOW_DATA),0)
+DEFINES += HAVE_ALLOW_DATA
+endif
+
+
 # Enabling debug PRINTF
 DEBUG:=0
 ifneq ($(DEBUG),0)

--- a/doc/ethapp.asc
+++ b/doc/ethapp.asc
@@ -474,6 +474,7 @@ The following standard Status Words are returned for all APDUs - some specific S
 |===============================================================================================
 | *SW*     | *Description*
 |   6501   | TransactionType not supported
+|   6502   | Not enough space for conversion from uint32_t to string
 |   6700   | Incorrect length
 |   6982   | Security status not satisfied (Canceled by user)
 |   6A80   | Invalid data

--- a/doc/ethapp.asc
+++ b/doc/ethapp.asc
@@ -474,7 +474,7 @@ The following standard Status Words are returned for all APDUs - some specific S
 |===============================================================================================
 | *SW*     | *Description*
 |   6501   | TransactionType not supported
-|   6502   | Not enough space for conversion from uint32_t to string
+|   6502   | Output buffer too small for snprintf input
 |   6700   | Incorrect length
 |   6982   | Security status not satisfied (Canceled by user)
 |   6A80   | Invalid data

--- a/doc/ethapp.asc
+++ b/doc/ethapp.asc
@@ -473,6 +473,7 @@ The following standard Status Words are returned for all APDUs - some specific S
 [width="80%"]
 |===============================================================================================
 | *SW*     | *Description*
+|   6501   | TransactionType not supported
 |   6700   | Incorrect length
 |   6982   | Security status not satisfied (Canceled by user)
 |   6A80   | Invalid data

--- a/src/chainConfig.h
+++ b/src/chainConfig.h
@@ -61,4 +61,6 @@ typedef struct chain_config_s {
     chain_kind_t kind;
 } chain_config_t;
 
+#define ETHEREUM_MAINNET_CHAINID 1
+
 #endif /* _CHAIN_CONFIG_H_ */

--- a/src/eth_plugin_handler.c
+++ b/src/eth_plugin_handler.c
@@ -59,6 +59,7 @@ void eth_plugin_prepare_query_contract_UI(ethQueryContractUI_t *queryContractUI,
 int eth_plugin_perform_init(uint8_t *contractAddress, ethPluginInitContract_t *init) {
     uint8_t i;
     const uint8_t **selectors;
+    return 0;
     dataContext.tokenContext.pluginAvailable = 0;
     // Handle hardcoded plugin list
     PRINTF("Selector %.*H\n", 4, init->selector);

--- a/src/eth_plugin_handler.c
+++ b/src/eth_plugin_handler.c
@@ -59,7 +59,6 @@ void eth_plugin_prepare_query_contract_UI(ethQueryContractUI_t *queryContractUI,
 int eth_plugin_perform_init(uint8_t *contractAddress, ethPluginInitContract_t *init) {
     uint8_t i;
     const uint8_t **selectors;
-    return 0;
     dataContext.tokenContext.pluginAvailable = 0;
     // Handle hardcoded plugin list
     PRINTF("Selector %.*H\n", 4, init->selector);

--- a/src/main.c
+++ b/src/main.c
@@ -714,7 +714,11 @@ void coin_main(chain_config_t *coin_config) {
 
                 if (N_storage.initialized != 0x01) {
                     internalStorage_t storage;
+#ifdef HAVE_ALLOW_DATA
+                    storage.dataAllowed = 0x01;
+#else
                     storage.dataAllowed = 0x00;
+#endif
                     storage.contractDetails = 0x00;
                     storage.displayNonce = 0x00;
                     storage.initialized = 0x01;

--- a/src/shared_context.h
+++ b/src/shared_context.h
@@ -158,7 +158,9 @@ typedef struct txStringProperties_t {
     char fullAddress[43];
     char fullAmount[50];
     char maxFee[50];
-    char nonce[8];  // 10M tx per account ought to be enough for everybody
+    char nonce[8];    // 10M tx per account ought to be enough for everybody
+    char chainID[8];  // 10M different chainID ought to be enough for people to find a unique
+                      // chainID for their token / chain.
 } txStringProperties_t;
 
 typedef struct strDataTmp_t {

--- a/src/utils.c
+++ b/src/utils.c
@@ -54,7 +54,8 @@ int local_strchr(char *string, char ch) {
 }
 
 // Almost like U4BE except that it takes `size` as a parameter.
-uint32_t u32_from_BE(uint8_t *in, uint8_t size) {
+// The `strict` parameter defines whether we should throw in case of a length > 4.
+uint32_t u32_from_BE(uint8_t *in, uint8_t size, bool strict) {
     uint32_t res = 0;
     if (size == 1) {
         res = in[0];
@@ -62,8 +63,11 @@ uint32_t u32_from_BE(uint8_t *in, uint8_t size) {
         res = (in[0] << 8) | in[1];
     } else if (size == 3) {
         res = (in[0] << 16) | (in[1] << 8) | in[2];
-    } else {
+    } else if (size == 4) {
         res = (in[0] << 24) | (in[1] << 16) | (in[2] << 8) | in[3];
+    } else if (strict && size != 0) {
+        PRINTF("Unexpected format\n");
+        THROW(EXCEPTION);
     }
     return res;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -72,45 +72,6 @@ uint32_t u32_from_BE(uint8_t *in, uint8_t size, bool strict) {
     return res;
 }
 
-// Converts a uint32_t to a string.
-void u32_to_str(char *dest, uint32_t in, uint8_t dest_size) {
-    uint8_t i = 0;
-
-    // Get the first digit (in case it's 0).
-    dest[i] = in % 10 + '0';
-    in /= 10;
-    i++;
-
-    // Get every digit.
-    while (in != 0) {
-        if (i >= dest_size) {
-            THROW(6502);
-        }
-        dest[i] = in % 10 + '0';
-        in /= 10;
-        i++;
-    }
-
-    // Null terminate the string.
-    dest[i] = '\0';
-    i--;
-
-    // Reverse the string
-    uint8_t end = i;
-    char tmp;
-    i = 0;
-    while (i < end) {
-        // Swap the first and last elements.
-        tmp = dest[i];
-        dest[i] = dest[end];
-        dest[end] = tmp;
-
-        // Decrease the interval size.
-        i++;
-        end--;
-    }
-}
-
 void amountToString(uint8_t *amount,
                     uint8_t amount_size,
                     uint8_t decimals,

--- a/src/utils.h
+++ b/src/utils.h
@@ -28,7 +28,11 @@ void convertUint256BE(uint8_t* data, uint32_t length, uint256_t* target);
 
 int local_strchr(char* string, char ch);
 
-uint32_t getV(txContent_t* txContent);
+// `itoa` for uint32_t.
+void u32_to_str(char* dest, uint8_t dest_size, uint32_t in);
+
+// Converts a list of bytes (in BE) of length `size` to a uint32_t.
+uint32_t u32_from_BE(uint8_t* in, uint8_t size);
 
 void amountToString(uint8_t* amount,
                     uint8_t amount_len,

--- a/src/utils.h
+++ b/src/utils.h
@@ -28,9 +28,6 @@ void convertUint256BE(uint8_t* data, uint32_t length, uint256_t* target);
 
 int local_strchr(char* string, char ch);
 
-// `itoa` for uint32_t.
-void u32_to_str(char* dest, uint8_t dest_size, uint32_t in);
-
 // Converts a list of bytes (in BE) of length `size` to a uint32_t. `strict` will make the function
 // throw if the size is > 4.
 uint32_t u32_from_BE(uint8_t* in, uint8_t size, bool strict);

--- a/src/utils.h
+++ b/src/utils.h
@@ -31,7 +31,8 @@ int local_strchr(char* string, char ch);
 // `itoa` for uint32_t.
 void u32_to_str(char* dest, uint8_t dest_size, uint32_t in);
 
-// Converts a list of bytes (in BE) of length `size` to a uint32_t.
+// Converts a list of bytes (in BE) of length `size` to a uint32_t. `strict` will make the function
+// throw if the size is > 4.
 uint32_t u32_from_BE(uint8_t* in, uint8_t size, bool strict);
 
 void amountToString(uint8_t* amount,

--- a/src/utils.h
+++ b/src/utils.h
@@ -32,7 +32,7 @@ int local_strchr(char* string, char ch);
 void u32_to_str(char* dest, uint8_t dest_size, uint32_t in);
 
 // Converts a list of bytes (in BE) of length `size` to a uint32_t.
-uint32_t u32_from_BE(uint8_t* in, uint8_t size);
+uint32_t u32_from_BE(uint8_t* in, uint8_t size, bool strict);
 
 void amountToString(uint8_t* amount,
                     uint8_t amount_len,

--- a/src_common/ethUstream.c
+++ b/src_common/ethUstream.c
@@ -266,7 +266,7 @@ static parserStatus_e processTxInternal(txContext_t *context) {
         // EIP 2718: TransactionType might be present before the TransactionPayload.
         if (*context->workBuffer > 0x00 && *context->workBuffer < 0x7f) {
             PRINTF("TX TYPE: %u\n", context->txType);
-            if (*context->workBuffer < MIN_TX_TYPE || *context->workBuffer > MAX_TX_TYPE) {
+            if (*context->workBuffer <= MIN_TX_TYPE || *context->workBuffer >= MAX_TX_TYPE) {
                 PRINTF("Transaction type not supported\n");
                 return USTREAM_FAULT;
             }

--- a/src_common/ethUstream.c
+++ b/src_common/ethUstream.c
@@ -249,25 +249,9 @@ static void processV(txContext_t *context) {
 }
 
 static parserStatus_e processTxInternal(txContext_t *context) {
-    // EIP 2718: TransactionType might be present before the TransactionPayload.
-    uint8_t txType = *context->workBuffer;
-    if (txType >= MIN_TX_TYPE && txType <= MAX_TX_TYPE) {
-        PRINTF("TX TYPE: %u\n", txType);
-
-        // Enumerate through all supported txTypes here...
-        if (txType == LEGACY_TX) {
-            context->txType = txType;
-            context->workBuffer++;
-        } else {
-            PRINTF("Transaction type not supported\n");
-            return USTREAM_FAULT;
-        }
-    }
-
-    // Parse the TransactionPayload.
     for (;;) {
         customStatus_e customStatus = CUSTOM_NOT_HANDLED;
-        // EIP 155 style transasction
+        // EIP 155 style transaction
         if (context->currentField == TX_RLP_DONE) {
             return USTREAM_FINISHED;
         }

--- a/src_common/ethUstream.c
+++ b/src_common/ethUstream.c
@@ -266,7 +266,7 @@ static parserStatus_e processTxInternal(txContext_t *context) {
         // EIP 2718: TransactionType might be present before the TransactionPayload.
         if (*context->workBuffer > 0x00 && *context->workBuffer < 0x7f) {
             PRINTF("TX TYPE: %u\n", context->txType);
-            if (*context->workBuffer < MIN_TX_TYPE || *context->workBuffer > MAX_TX_TYPE ) {
+            if (*context->workBuffer < MIN_TX_TYPE || *context->workBuffer > MAX_TX_TYPE) {
                 PRINTF("Transaction type not supported\n");
                 return USTREAM_FAULT;
             }

--- a/src_common/ethUstream.c
+++ b/src_common/ethUstream.c
@@ -436,7 +436,7 @@ static parserStatus_e processTxInternal(txContext_t *context) {
     for (;;) {
         customStatus_e customStatus = CUSTOM_NOT_HANDLED;
         // EIP 155 style transaction
-        if (IS_PARSING_DONE(context)) {
+        if (PARSING_IS_DONE(context)) {
             return USTREAM_FINISHED;
         }
         // Old style transaction

--- a/src_common/ethUstream.c
+++ b/src_common/ethUstream.c
@@ -265,9 +265,13 @@ static parserStatus_e processTxInternal(txContext_t *context) {
         }
         // EIP 2718: TransactionType might be present before the TransactionPayload.
         if (*context->workBuffer > 0x00 && *context->workBuffer < 0x7f) {
+            PRINTF("TX TYPE: %u\n", context->txType);
+            if (*context->workBuffer < MIN_TX_TYPE || *context->workBuffer > MAX_TX_TYPE ) {
+                PRINTF("Transaction type not supported\n");
+                return USTREAM_FAULT;
+            }
             context->txType = *context->workBuffer;
             context->workBuffer++;
-            PRINTF("TX TYPE: %u\n", context->txType);
         }
         if (!context->processingField) {
             PRINTF("PROCESSING FIELD\n");

--- a/src_common/ethUstream.c
+++ b/src_common/ethUstream.c
@@ -263,7 +263,14 @@ static parserStatus_e processTxInternal(txContext_t *context) {
         if (context->commandLength == 0) {
             return USTREAM_PROCESSING;
         }
+        // EIP 2718: TransactionType might be present before the TransactionPayload.
+        if (*context->workBuffer > 0x00 && *context->workBuffer < 0x7f) {
+            context->txType = *context->workBuffer;
+            context->workBuffer++;
+            PRINTF("TX TYPE: %u\n", context->txType);
+        }
         if (!context->processingField) {
+            PRINTF("PROCESSING FIELD\n");
             bool canDecode = false;
             uint32_t offset;
             while (context->commandLength != 0) {

--- a/src_common/ethUstream.c
+++ b/src_common/ethUstream.c
@@ -264,7 +264,7 @@ static parserStatus_e processTxInternal(txContext_t *context) {
             return USTREAM_PROCESSING;
         }
         // EIP 2718: TransactionType might be present before the TransactionPayload.
-        if (*context->workBuffer > 0x00 && *context->workBuffer < 0x7f) {
+        if (*context->workBuffer >= MIN_TX_TYPE && *context->workBuffer <= MAX_TX_TYPE) {
             uint8_t maybeType = *context->workBuffer;
             PRINTF("TX TYPE: %u\n", maybeType);
 

--- a/src_common/ethUstream.c
+++ b/src_common/ethUstream.c
@@ -265,7 +265,7 @@ static parserStatus_e processTxInternal(txContext_t *context) {
         }
         // EIP 2718: TransactionType might be present before the TransactionPayload.
         if (*context->workBuffer > 0x00 && *context->workBuffer < 0x7f) {
-            PRINTF("TX TYPE: %u\n", context->txType);
+            PRINTF("TX TYPE: %u\n", *context->workBuffer);
             if (*context->workBuffer <= MIN_TX_TYPE || *context->workBuffer >= MAX_TX_TYPE) {
                 PRINTF("Transaction type not supported\n");
                 return USTREAM_FAULT;
@@ -274,7 +274,6 @@ static parserStatus_e processTxInternal(txContext_t *context) {
             context->workBuffer++;
         }
         if (!context->processingField) {
-            PRINTF("PROCESSING FIELD\n");
             bool canDecode = false;
             uint32_t offset;
             while (context->commandLength != 0) {

--- a/src_common/ethUstream.c
+++ b/src_common/ethUstream.c
@@ -342,7 +342,6 @@ static bool processEIP2930Tx(txContext_t *context) {
 }
 
 static bool processLegacyTx(txContext_t *context) {
-    PRINTF("Processing legacy\n");
     switch (context->currentField) {
         case LEGACY_RLP_CONTENT:
             processContent(context);

--- a/src_common/ethUstream.c
+++ b/src_common/ethUstream.c
@@ -265,13 +265,17 @@ static parserStatus_e processTxInternal(txContext_t *context) {
         }
         // EIP 2718: TransactionType might be present before the TransactionPayload.
         if (*context->workBuffer > 0x00 && *context->workBuffer < 0x7f) {
-            PRINTF("TX TYPE: %u\n", *context->workBuffer);
-            if (*context->workBuffer <= MIN_TX_TYPE || *context->workBuffer >= MAX_TX_TYPE) {
+            uint8_t maybeType = *context->workBuffer;
+            PRINTF("TX TYPE: %u\n", maybeType);
+
+            // Enumerate through all supported txTypes here...
+            if (maybeType == LEGACY_TX) {
+                context->txType = *context->workBuffer;
+                context->workBuffer++;
+            } else {
                 PRINTF("Transaction type not supported\n");
                 return USTREAM_FAULT;
             }
-            context->txType = *context->workBuffer;
-            context->workBuffer++;
         }
         if (!context->processingField) {
             bool canDecode = false;

--- a/src_common/ethUstream.c
+++ b/src_common/ethUstream.c
@@ -145,7 +145,6 @@ static void processChainID(txContext_t *context) {
         context->currentField++;
         context->processingField = false;
     }
-    PRINTF("chainID: %.*H\n", context->content->chainID.length, context->content->chainID.value);
 }
 
 static void processNonce(txContext_t *context) {

--- a/src_common/ethUstream.h
+++ b/src_common/ethUstream.h
@@ -55,10 +55,7 @@ typedef enum rlpTxField_e {
 
 // EIP 2718 TransactionType
 typedef enum txType_e {
-    MIN_TX_TYPE,
     LEGACY_TX,
-    BERLIN_TX,
-    MAX_TX_TYPE,
 } txType_e;
 
 typedef enum parserStatus_e {

--- a/src_common/ethUstream.h
+++ b/src_common/ethUstream.h
@@ -53,6 +53,12 @@ typedef enum rlpTxField_e {
     TX_RLP_DONE
 } rlpTxField_e;
 
+// EIP 2718 TransactionType
+typedef enum txType_e {
+    LegacyTransaction = 1,
+    BerlinTransaction = 2
+} txType_e;
+
 typedef enum parserStatus_e {
     USTREAM_PROCESSING,
     USTREAM_SUSPENDED,
@@ -93,6 +99,7 @@ typedef struct txContext_t {
     ustreamProcess_t customProcessor;
     txContent_t *content;
     void *extra;
+    uint8_t txType;
 } txContext_t;
 
 void initTx(txContext_t *context,

--- a/src_common/ethUstream.h
+++ b/src_common/ethUstream.h
@@ -40,7 +40,7 @@ typedef customStatus_e (*ustreamProcess_t)(struct txContext_t *context);
 // First variant of every Tx enum.
 #define RLP_NONE 0
 
-#define IS_PARSING_DONE(ctx)                                            \
+#define PARSING_IS_DONE(ctx)                                            \
     ((ctx->txType == LEGACY && ctx->currentField == LEGACY_RLP_DONE) || \
      (ctx->txType == EIP2930 && ctx->currentField == EIP2930_RLP_DONE))
 

--- a/src_common/ethUstream.h
+++ b/src_common/ethUstream.h
@@ -53,6 +53,9 @@ typedef enum rlpTxField_e {
     TX_RLP_DONE
 } rlpTxField_e;
 
+#define MIN_TX_TYPE 0x00
+#define MAX_TX_TYPE 0x7f
+
 // EIP 2718 TransactionType
 typedef enum txType_e {
     LEGACY_TX,

--- a/src_common/ethUstream.h
+++ b/src_common/ethUstream.h
@@ -55,8 +55,10 @@ typedef enum rlpTxField_e {
 
 // EIP 2718 TransactionType
 typedef enum txType_e {
-    LegacyTransaction = 1,
-    BerlinTransaction = 2
+    MIN_TX_TYPE,
+    LEGACY_TX,
+    BERLIN_TX,
+    MAX_TX_TYPE,
 } txType_e;
 
 typedef enum parserStatus_e {

--- a/src_common/ethUstream.h
+++ b/src_common/ethUstream.h
@@ -58,7 +58,7 @@ typedef enum rlpTxField_e {
 
 // EIP 2718 TransactionType
 typedef enum txType_e {
-    LEGACY_TX,
+    LEGACY_TX = 1,
 } txType_e;
 
 typedef enum parserStatus_e {

--- a/src_features/signTx/cmd_signTx.c
+++ b/src_features/signTx/cmd_signTx.c
@@ -40,6 +40,22 @@ void handleSign(uint8_t p1,
         }
         dataPresent = false;
         dataContext.tokenContext.pluginAvailable = 0;
+
+        // EIP 2718: TransactionType might be present before the TransactionPayload.
+        uint8_t txType = *workBuffer;
+        if (txType >= MIN_TX_TYPE && txType <= MAX_TX_TYPE) {
+            PRINTF("Transaction type: %u\n", txType);
+
+            // Enumerate through all supported txTypes here...
+            if (txType == LEGACY_TX) {
+                txContext.txType = txType;
+                workBuffer++;
+                dataLength--;
+            } else {
+                PRINTF("Transaction type not supported\n");
+                THROW(0x6501);
+            }
+        }
         initTx(&txContext, &global_sha3, &tmpContent.txContent, customProcessor, NULL);
     } else if (p1 != P1_MORE) {
         THROW(0x6B00);

--- a/src_features/signTx/cmd_signTx.c
+++ b/src_features/signTx/cmd_signTx.c
@@ -44,10 +44,8 @@ void handleSign(uint8_t p1,
         // EIP 2718: TransactionType might be present before the TransactionPayload.
         uint8_t txType = *workBuffer;
         if (txType >= MIN_TX_TYPE && txType <= MAX_TX_TYPE) {
-            PRINTF("Transaction type: %u\n", txType);
-
             // Enumerate through all supported txTypes here...
-            if (txType == LEGACY_TX) {
+            if (txType == EIP2930) {
                 txContext.txType = txType;
                 workBuffer++;
                 dataLength--;
@@ -55,6 +53,8 @@ void handleSign(uint8_t p1,
                 PRINTF("Transaction type not supported\n");
                 THROW(0x6501);
             }
+        } else {
+            txContext.txType = LEGACY;
         }
         initTx(&txContext, &global_sha3, &tmpContent.txContent, customProcessor, NULL);
     } else if (p1 != P1_MORE) {
@@ -67,7 +67,7 @@ void handleSign(uint8_t p1,
         PRINTF("Signature not initialized\n");
         THROW(0x6985);
     }
-    if (txContext.currentField == TX_RLP_NONE) {
+    if (txContext.currentField == RLP_NONE) {
         PRINTF("Parser not initialized\n");
         THROW(0x6985);
     }

--- a/src_features/signTx/logic_signTx.c
+++ b/src_features/signTx/logic_signTx.c
@@ -389,8 +389,9 @@ void finalizeParsing(bool direct) {
     if (genericUI) {
         if (txContext.txType == LEGACY) {
             uint32_t id = u32_from_BE(txContext.content->v, txContext.content->vLength, true);
+            PRINTF("Chain ID: %u\n", id);
             uint8_t res =
-                snprintf(strings.common.chainID, sizeof(strings.common.chainID), "%u", id);
+                snprintf(strings.common.chainID, sizeof(strings.common.chainID), "%d", id);
             if (res >= sizeof(strings.common.chainID)) {
                 // If the return value is higher or equal to the size passed in as parameter, then
                 // the output was truncated. Return the appropriate error code.

--- a/src_features/signTx/logic_signTx.c
+++ b/src_features/signTx/logic_signTx.c
@@ -389,7 +389,13 @@ void finalizeParsing(bool direct) {
     if (genericUI) {
         if (txContext.txType == LEGACY) {
             uint32_t id = u32_from_BE(txContext.content->v, txContext.content->vLength, true);
-            u32_to_str((char *) strings.common.chainID, sizeof(strings.common.chainID), id);
+            uint8_t res =
+                snprintf(strings.common.chainID, sizeof(strings.common.chainID), "%u", id);
+            if (res >= sizeof(strings.common.chainID)) {
+                // If the return value is higher or equal to the size passed in as parameter, then
+                // the output was truncated. Return the appropriate error code.
+                THROW(0x6502);
+            }
         } else if (txContext.txType == EIP2930) {
             uint256_t chainID;
             convertUint256BE(tmpContent.txContent.chainID.value,

--- a/src_features/signTx/logic_signTx.c
+++ b/src_features/signTx/logic_signTx.c
@@ -57,7 +57,6 @@ customStatus_e customProcessor(txContext_t *context) {
                                         context->currentFieldLength);
                 dataContext.tokenContext.pluginAvailable =
                     eth_plugin_perform_init(tmpContent.txContent.destination, &pluginInit);
-                PRINTF("a\n");
             }
             PRINTF("pluginAvailable %d\n", dataContext.tokenContext.pluginAvailable);
             if (dataContext.tokenContext.pluginAvailable) {

--- a/src_features/signTx/logic_signTx.c
+++ b/src_features/signTx/logic_signTx.c
@@ -248,9 +248,9 @@ void finalizeParsing(bool direct) {
         uint32_t id = 0;
 
         if (txContext.txType == LEGACY) {
-            id = u32_from_BE(txContext.content->v, txContext.content->vLength);
+            id = u32_from_BE(txContext.content->v, txContext.content->vLength, true);
         } else if (txContext.txType == EIP2930) {
-            id = u32_from_BE(txContext.content->chainID.value, txContext.content->chainID.length);
+            id = u32_from_BE(txContext.content->chainID.value, txContext.content->chainID.length, false);
         } else {
             PRINTF("TxType `%u` not supported while checking for chainID\n", txContext.txType);
             return;
@@ -388,7 +388,7 @@ void finalizeParsing(bool direct) {
     // Prepare chainID field
     if (genericUI) {
         if (txContext.txType == LEGACY) {
-            uint32_t id = u32_from_BE(txContext.content->v, txContext.content->vLength);
+            uint32_t id = u32_from_BE(txContext.content->v, txContext.content->vLength, true);
             u32_to_str((char *) strings.common.chainID, sizeof(strings.common.chainID), id);
         } else if (txContext.txType == EIP2930) {
             uint256_t chainID;

--- a/src_features/signTx/logic_signTx.c
+++ b/src_features/signTx/logic_signTx.c
@@ -255,7 +255,6 @@ void finalizeParsing(bool direct) {
             return;
         }
 
-        PRINTF("OFFICIAL: %u, RECEIVED: %u\n", chainConfig->chainId, id);
         if (chainConfig->chainId != id) {
             PRINTF("Invalid chainID %u expected %u\n", id, chainConfig->chainId);
             reset_app_context();

--- a/src_features/signTx/logic_signTx.c
+++ b/src_features/signTx/logic_signTx.c
@@ -249,7 +249,9 @@ void finalizeParsing(bool direct) {
         if (txContext.txType == LEGACY) {
             id = u32_from_BE(txContext.content->v, txContext.content->vLength, true);
         } else if (txContext.txType == EIP2930) {
-            id = u32_from_BE(txContext.content->chainID.value, txContext.content->chainID.length, false);
+            id = u32_from_BE(txContext.content->chainID.value,
+                             txContext.content->chainID.length,
+                             false);
         } else {
             PRINTF("TxType `%u` not supported while checking for chainID\n", txContext.txType);
             return;

--- a/src_features/signTx/ui_common_signTx.c
+++ b/src_features/signTx/ui_common_signTx.c
@@ -8,7 +8,7 @@ unsigned int io_seproxyhal_touch_tx_ok(const bagl_element_t *e) {
     uint8_t signatureLength;
     cx_ecfp_private_key_t privateKey;
     uint32_t tx = 0;
-    uint32_t v = u32_from_BE(tmpContent.txContent.v, tmpContent.txContent.vLength);
+    uint32_t v = u32_from_BE(tmpContent.txContent.v, tmpContent.txContent.vLength, true);
     io_seproxyhal_io_heartbeat();
     os_perso_derive_node_bip32(CX_CURVE_256K1,
                                tmpCtx.transactionContext.bip32Path,

--- a/src_features/signTx/ui_common_signTx.c
+++ b/src_features/signTx/ui_common_signTx.c
@@ -8,7 +8,7 @@ unsigned int io_seproxyhal_touch_tx_ok(const bagl_element_t *e) {
     uint8_t signatureLength;
     cx_ecfp_private_key_t privateKey;
     uint32_t tx = 0;
-    uint32_t v = getV(&tmpContent.txContent);
+    uint32_t v = u32_from_BE(tmpContent.txContent.v, tmpContent.txContent.vLength);
     io_seproxyhal_io_heartbeat();
     os_perso_derive_node_bip32(CX_CURVE_256K1,
                                tmpCtx.transactionContext.bip32Path,

--- a/src_features/signTx/ui_flow_signTx.c
+++ b/src_features/signTx/ui_flow_signTx.c
@@ -173,9 +173,9 @@ void ux_approve_tx(bool dataPresent) {
 
     uint32_t id;
     if (txContext.txType == LEGACY) {
-        id = u32_from_BE(txContext.content->v, txContext.content->vLength);
+        id = u32_from_BE(txContext.content->v, txContext.content->vLength, true);
     } else if (txContext.txType == EIP2930) {
-        id = u32_from_BE(txContext.content->chainID.value, txContext.content->chainID.length);
+        id = u32_from_BE(txContext.content->chainID.value, txContext.content->chainID.length, false);
     } else {
         PRINTF("TxType `%u` not supported while preparing to approve tx\n", txContext.txType);
         THROW(0x6501);

--- a/src_features/signTx/ui_flow_signTx.c
+++ b/src_features/signTx/ui_flow_signTx.c
@@ -175,7 +175,8 @@ void ux_approve_tx(bool dataPresent) {
     if (txContext.txType == LEGACY) {
         id = u32_from_BE(txContext.content->v, txContext.content->vLength, true);
     } else if (txContext.txType == EIP2930) {
-        id = u32_from_BE(txContext.content->chainID.value, txContext.content->chainID.length, false);
+        id =
+            u32_from_BE(txContext.content->chainID.value, txContext.content->chainID.length, false);
     } else {
         PRINTF("TxType `%u` not supported while preparing to approve tx\n", txContext.txType);
         THROW(0x6501);

--- a/src_features/signTx/ui_flow_signTx.c
+++ b/src_features/signTx/ui_flow_signTx.c
@@ -1,5 +1,7 @@
 #include "shared_context.h"
 #include "ui_callbacks.h"
+#include "chainConfig.h"
+#include "utils.h"
 
 // clang-format off
 UX_STEP_NOCB(
@@ -85,7 +87,7 @@ UX_FLOW(ux_confirm_parameter_flow,
 
 //////////////////////////////////////////////////////////////////////
 // clang-format off
-UX_STEP_NOCB(ux_approval_tx_1_step,
+UX_STEP_NOCB(ux_approval_review_step,
     pnn,
     {
       &C_icon_eye,
@@ -93,28 +95,35 @@ UX_STEP_NOCB(ux_approval_tx_1_step,
       "transaction",
     });
 UX_STEP_NOCB(
-    ux_approval_tx_2_step,
+    ux_approval_amount_step,
     bnnn_paging,
     {
       .title = "Amount",
       .text = strings.common.fullAmount
     });
 UX_STEP_NOCB(
-    ux_approval_tx_3_step,
+    ux_approval_address_step,
     bnnn_paging,
     {
       .title = "Address",
       .text = strings.common.fullAddress,
     });
 UX_STEP_NOCB(
-    ux_approval_tx_4_step,
+    ux_approval_fees_step,
     bnnn_paging,
     {
       .title = "Max Fees",
       .text = strings.common.maxFee,
     });
+UX_STEP_NOCB(
+    ux_approval_chainid_step,
+    bnnn_paging,
+    {
+      .title = "Chain ID",
+      .text = strings.common.chainID,
+    });
 UX_STEP_CB(
-    ux_approval_tx_5_step,
+    ux_approval_accept_step,
     pbb,
     io_seproxyhal_touch_tx_ok(NULL),
     {
@@ -123,7 +132,7 @@ UX_STEP_CB(
       "and send",
     });
 UX_STEP_CB(
-    ux_approval_tx_6_step,
+    ux_approval_reject_step,
     pb,
     io_seproxyhal_touch_tx_cancel(NULL),
     {
@@ -132,14 +141,14 @@ UX_STEP_CB(
     });
 
 UX_STEP_NOCB(
-    ux_approval_tx_display_nonce_step,
+    ux_approval_nonce_step,
     bnnn_paging,
     {
       .title = "Nonce",
       .text = strings.common.nonce,
     });
 
-UX_STEP_NOCB(ux_approval_tx_data_warning_step,
+UX_STEP_NOCB(ux_approval_data_warning_step,
     pbb,
     {
       &C_icon_warning,
@@ -148,22 +157,35 @@ UX_STEP_NOCB(ux_approval_tx_data_warning_step,
     });
 // clang-format on
 
-const ux_flow_step_t *ux_approval_tx_flow_[9];
+const ux_flow_step_t *ux_approval_tx_flow_[10];
 
 void ux_approve_tx(bool dataPresent) {
     int step = 0;
-    ux_approval_tx_flow_[step++] = &ux_approval_tx_1_step;
+    ux_approval_tx_flow_[step++] = &ux_approval_review_step;
     if (dataPresent && !N_storage.contractDetails) {
-        ux_approval_tx_flow_[step++] = &ux_approval_tx_data_warning_step;
+        ux_approval_tx_flow_[step++] = &ux_approval_data_warning_step;
     }
-    ux_approval_tx_flow_[step++] = &ux_approval_tx_2_step;
-    ux_approval_tx_flow_[step++] = &ux_approval_tx_3_step;
+    ux_approval_tx_flow_[step++] = &ux_approval_amount_step;
+    ux_approval_tx_flow_[step++] = &ux_approval_address_step;
     if (N_storage.displayNonce) {
-        ux_approval_tx_flow_[step++] = &ux_approval_tx_display_nonce_step;
+        ux_approval_tx_flow_[step++] = &ux_approval_nonce_step;
     }
-    ux_approval_tx_flow_[step++] = &ux_approval_tx_4_step;
-    ux_approval_tx_flow_[step++] = &ux_approval_tx_5_step;
-    ux_approval_tx_flow_[step++] = &ux_approval_tx_6_step;
+
+    uint32_t id;
+    if (txContext.txType == LEGACY) {
+        id = u32_from_BE(txContext.content->v, txContext.content->vLength);
+    } else if (txContext.txType == EIP2930) {
+        id = u32_from_BE(txContext.content->chainID.value, txContext.content->chainID.length);
+    } else {
+        PRINTF("TxType `%u` not supported while preparing to approve tx\n", txContext.txType);
+        THROW(0x6501);
+    }
+    if (id != ETHEREUM_MAINNET_CHAINID) {
+        ux_approval_tx_flow_[step++] = &ux_approval_chainid_step;
+    }
+    ux_approval_tx_flow_[step++] = &ux_approval_fees_step;
+    ux_approval_tx_flow_[step++] = &ux_approval_accept_step;
+    ux_approval_tx_flow_[step++] = &ux_approval_reject_step;
     ux_approval_tx_flow_[step++] = FLOW_END_STEP;
 
     ux_flow_init(0, ux_approval_tx_flow_, NULL);


### PR DESCRIPTION
[EIP 2718](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2718.md) introduces Typed Transaction. Transactions can now have a single byte between 0 and 0x7f to uniquely identify their type.

This PR adapts the txdata parser to support those types of transactions.
It also adds support for EIP2930 which adds a new transaction type (`txtype 01`).
This PR also adds the feature of displaying the ChainID when it's different than 1.