### PR TITLE
Security review

### DIFF
--- a/src/eth_plugin_handler.c
+++ b/src/eth_plugin_handler.c
@@ -146,6 +146,8 @@ eth_plugin_result_t eth_plugin_call(int method, void *parameter) {
 
     switch (method) {
         case ETH_PLUGIN_INIT_CONTRACT:
+            ((ethPluginInitContract_t *) parameter)->interfaceVersion =
+                ETH_PLUGIN_INTERFACE_VERSION_1;
             ((ethPluginInitContract_t *) parameter)->result = ETH_PLUGIN_RESULT_UNAVAILABLE;
             ((ethPluginInitContract_t *) parameter)->pluginSharedRW = &pluginRW;
             ((ethPluginInitContract_t *) parameter)->pluginSharedRO = &pluginRO;

--- a/src/eth_plugin_interface.h
+++ b/src/eth_plugin_interface.h
@@ -10,6 +10,10 @@
 #define PLUGIN_ID_LENGTH 30
 
 typedef enum {
+    ETH_PLUGIN_INTERFACE_VERSION_1 = 1  // Version 1
+} eth_plugin_interface_version_t;
+
+typedef enum {
 
     ETH_PLUGIN_INIT_CONTRACT = 0x0101,
     ETH_PLUGIN_PROVIDE_PARAMETER = 0x0102,
@@ -61,8 +65,10 @@ typedef struct ethPluginSharedRO_t {
 // Init Contract
 
 typedef struct ethPluginInitContract_t {
-    // in
+    uint8_t interfaceVersion;
+    uint8_t result;
 
+    // in
     ethPluginSharedRW_t *pluginSharedRW;
     ethPluginSharedRO_t *pluginSharedRO;
     uint8_t *pluginContext;
@@ -71,8 +77,6 @@ typedef struct ethPluginInitContract_t {
     uint32_t dataSize;
 
     char *alias;  // 29 bytes alias if ETH_PLUGIN_RESULT_OK_ALIAS set
-
-    uint8_t result;
 
 } ethPluginInitContract_t;
 

--- a/src/eth_plugin_interface.h
+++ b/src/eth_plugin_interface.h
@@ -72,9 +72,9 @@ typedef struct ethPluginInitContract_t {
     ethPluginSharedRW_t *pluginSharedRW;
     ethPluginSharedRO_t *pluginSharedRO;
     uint8_t *pluginContext;
-    uint32_t pluginContextLength;
+    size_t pluginContextLength;
     uint8_t *selector;  // 4 bytes selector
-    uint32_t dataSize;
+    size_t dataSize;
 
     char *alias;  // 29 bytes alias if ETH_PLUGIN_RESULT_OK_ALIAS set
 
@@ -144,9 +144,9 @@ typedef struct ethQueryContractID_t {
     uint8_t *pluginContext;
 
     char *name;
-    uint32_t nameLength;
+    size_t nameLength;
     char *version;
-    uint32_t versionLength;
+    size_t versionLength;
 
     uint8_t result;
 
@@ -160,9 +160,9 @@ typedef struct ethQueryContractUI_t {
     uint8_t *pluginContext;
     uint8_t screenIndex;
     char *title;
-    uint32_t titleLength;
+    size_t titleLength;
     char *msg;
-    uint32_t msgLength;
+    size_t msgLength;
 
     uint8_t result;
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -22,6 +22,7 @@
 #include "ethUtils.h"
 #include "uint256.h"
 #include "tokens.h"
+#include "utils.h"
 
 static const unsigned char hex_digits[] =
     {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
@@ -98,10 +99,10 @@ bool uint256_to_decimal(const uint8_t *value, char *out, size_t out_len) {
     return true;
 }
 
-void amountToString(uint8_t *amount,
-                    uint8_t amount_size,
+void amountToString(const uint8_t *amount,
+                    uint8_t amount_size __attribute__((unused)),
                     uint8_t decimals,
-                    char *ticker,
+                    const char *ticker,
                     char *out_buffer,
                     uint8_t out_buffer_size) {
     char tmp_buffer[100];

--- a/src/utils.h
+++ b/src/utils.h
@@ -34,10 +34,10 @@ uint32_t u32_from_BE(uint8_t* in, uint8_t size, bool strict);
 
 bool uint256_to_decimal(const uint8_t* value, char* out, size_t out_len);
 
-void amountToString(uint8_t* amount,
+void amountToString(const uint8_t* amount,
                     uint8_t amount_len,
                     uint8_t decimals,
-                    char* ticker,
+                    const char* ticker,
                     char* out_buffer,
                     uint8_t out_buffer_size);
 

--- a/src_common/ethUtils.h
+++ b/src_common/ethUtils.h
@@ -60,9 +60,10 @@ bool adjustDecimals(char *src,
                     uint32_t targetLength,
                     uint8_t decimals);
 
-__attribute__((no_instrument_function)) inline int allzeroes(uint8_t *buf, int n) {
-    for (int i = 0; i < n; ++i) {
-        if (buf[i]) {
+__attribute__((no_instrument_function)) inline int allzeroes(void *buf, size_t n) {
+    uint8_t *p = (uint8_t *) buf;
+    for (size_t i = 0; i < n; ++i) {
+        if (p[i]) {
             return 0;
         }
     }
@@ -77,6 +78,6 @@ __attribute__((no_instrument_function)) inline int ismaxint(uint8_t *buf, int n)
     return 1;
 }
 
-static const uint8_t const HEXDIGITS[] = "0123456789abcdef";
+static const char HEXDIGITS[] = "0123456789abcdef";
 
 #endif /* _ETHUTILS_H_ */


### PR DESCRIPTION
This PR adds an interface version to the plugin interface. External plugins can check this interface version, and return an error if they are not compatible with it. This allows to detect discrepancies between the Ethereum app and external plugins.

Additionally, it fixes a few compilation warnings in the Ethereum plugin SDK.