### PR TITLE
Added Moonriver to network

### DIFF
--- a/src_common/network.c
+++ b/src_common/network.c
@@ -19,6 +19,7 @@ const network_info_t NETWORK_MAPPING[] = {
     {.chain_id = 100, .name = "xDai", .ticker = "xDAI "},
     {.chain_id = 137, .name = "Polygon", .ticker = "MATIC "},
     {.chain_id = 250, .name = "Fantom", .ticker = "FTM "},
+    {.chain_id = 1285, .name = "Moonriver", .ticker = "MOVR "},
     {.chain_id = 42161, .name = "Arbitrum", .ticker = "AETH "},
     {.chain_id = 42220, .name = "Celo", .ticker = "CELO "},
     {.chain_id = 43114, .name = "Avalanche", .ticker = "AVAX "},


### PR DESCRIPTION
Adds Moonriver's Chain ID to the network mapping so that it displays the right ticker when using the Ethereum App