### PR TITLE
Define better prototypes and types

### DIFF
--- a/src/eth_plugin_interface.h
+++ b/src/eth_plugin_interface.h
@@ -76,7 +76,7 @@ typedef struct ethPluginInitContract_t {
     ethPluginSharedRO_t *pluginSharedRO;
     uint8_t *pluginContext;
     size_t pluginContextLength;
-    uint8_t *selector;  // 4 bytes selector
+    const uint8_t *selector;  // 4 bytes selector
     size_t dataSize;
 
     char *alias;  // 29 bytes alias if ETH_PLUGIN_RESULT_OK_ALIAS set
@@ -89,7 +89,7 @@ typedef struct ethPluginProvideParameter_t {
     ethPluginSharedRW_t *pluginSharedRW;
     ethPluginSharedRO_t *pluginSharedRO;
     uint8_t *pluginContext;
-    uint8_t *parameter;  // 32 bytes parameter
+    const uint8_t *parameter;  // 32 bytes parameter
     uint32_t parameterOffset;
 
     uint8_t result;
@@ -106,9 +106,9 @@ typedef struct ethPluginFinalize_t {
     uint8_t *tokenLookup1;  // set by the plugin if a token should be looked up
     uint8_t *tokenLookup2;
 
-    uint8_t *amount;   // set an uint256 pointer if uiType is UI_AMOUNT_ADDRESS
-    uint8_t *address;  // set to the destination address if uiType is UI_AMOUNT_ADDRESS. Set to the
-                       // user's address if uiType is UI_TYPE_GENERIC
+    const uint8_t *amount;   // set an uint256 pointer if uiType is UI_AMOUNT_ADDRESS
+    const uint8_t *address;  // set to the destination address if uiType is UI_AMOUNT_ADDRESS. Set
+                             // to the user's address if uiType is UI_TYPE_GENERIC
 
     uint8_t uiType;
     uint8_t numScreens;  // ignored if uiType is UI_AMOUNT_ADDRESS

--- a/src/eth_plugin_internal.c
+++ b/src/eth_plugin_internal.c
@@ -5,12 +5,12 @@ bool erc20_plugin_available_check(void);
 void erc20_plugin_call(int message, void* parameters);
 void compound_plugin_call(int message, void* parameters);
 
-void copy_address(uint8_t* dst, uint8_t* parameter, uint8_t dst_size) {
+void copy_address(uint8_t* dst, const uint8_t* parameter, uint8_t dst_size) {
     uint8_t copy_size = MIN(dst_size, ADDRESS_LENGTH);
     memmove(dst, parameter + PARAMETER_LENGTH - copy_size, copy_size);
 }
 
-void copy_parameter(uint8_t* dst, uint8_t* parameter, uint8_t dst_size) {
+void copy_parameter(uint8_t* dst, const uint8_t* parameter, uint8_t dst_size) {
     uint8_t copy_size = MIN(dst_size, PARAMETER_LENGTH);
     memmove(dst, parameter, copy_size);
 }

--- a/src/eth_plugin_internal.h
+++ b/src/eth_plugin_internal.h
@@ -6,9 +6,9 @@
 #define PARAMETER_LENGTH 32
 #define RUN_APPLICATION  1
 
-void copy_address(uint8_t* dst, uint8_t* parameter, uint8_t dst_size);
+void copy_address(uint8_t* dst, const uint8_t* parameter, uint8_t dst_size);
 
-void copy_parameter(uint8_t* dst, uint8_t* parameter, uint8_t dst_size);
+void copy_parameter(uint8_t* dst, const uint8_t* parameter, uint8_t dst_size);
 
 void erc721_plugin_call(int message, void* parameters);
 void erc1155_plugin_call(int message, void* parameters);

--- a/src/utils.c
+++ b/src/utils.c
@@ -115,7 +115,7 @@ void amountToString(const uint8_t *amount,
                     uint8_t decimals,
                     const char *ticker,
                     char *out_buffer,
-                    uint8_t out_buffer_size) {
+                    size_t out_buffer_size) {
     char tmp_buffer[100] = {0};
 
     if (uint256_to_decimal(amount, amount_size, tmp_buffer, sizeof(tmp_buffer)) == false) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -37,7 +37,7 @@ void amountToString(const uint8_t* amount,
                     uint8_t decimals,
                     const char* ticker,
                     char* out_buffer,
-                    uint8_t out_buffer_size);
+                    size_t out_buffer_size);
 
 bool parse_swap_config(uint8_t* config, uint8_t config_len, char* ticker, uint8_t* decimals);
 

--- a/src_common/ethUtils.c
+++ b/src_common/ethUtils.c
@@ -243,10 +243,10 @@ uint8_t *getNftContractAddress(const ethQueryContractUI_t *const msg) {
                          : msg->pluginSharedRO->txContent->destination);
 }
 
-bool adjustDecimals(char *src,
-                    uint32_t srcLength,
+bool adjustDecimals(const char *src,
+                    size_t srcLength,
                     char *target,
-                    uint32_t targetLength,
+                    size_t targetLength,
                     uint8_t decimals) {
     uint32_t startOffset;
     uint32_t lastZeroOffset = 0;

--- a/src_common/ethUtils.h
+++ b/src_common/ethUtils.h
@@ -61,10 +61,10 @@ void getEthDisplayableAddress(uint8_t *in,
 
 uint8_t *getNftContractAddress(const ethQueryContractUI_t *const msg);
 
-bool adjustDecimals(char *src,
-                    uint32_t srcLength,
+bool adjustDecimals(const char *src,
+                    size_t srcLength,
                     char *target,
-                    uint32_t targetLength,
+                    size_t targetLength,
                     uint8_t decimals);
 
 static __attribute__((no_instrument_function)) inline int allzeroes(void *buf, size_t n) {

--- a/src_common/network.c
+++ b/src_common/network.c
@@ -45,27 +45,27 @@ uint64_t get_chain_id(void) {
     return chain_id;
 }
 
-network_info_t *get_network(void) {
+const network_info_t *get_network(void) {
     uint64_t chain_id = get_chain_id();
-    for (uint8_t i = 0; i < sizeof(NETWORK_MAPPING) / sizeof(*NETWORK_MAPPING); i++) {
+    for (size_t i = 0; i < sizeof(NETWORK_MAPPING) / sizeof(*NETWORK_MAPPING); i++) {
         if (NETWORK_MAPPING[i].chain_id == chain_id) {
-            return (network_info_t *) PIC(&NETWORK_MAPPING[i]);
+            return (const network_info_t *) PIC(&NETWORK_MAPPING[i]);
         }
     }
     return NULL;
 }
 
-char *get_network_name(void) {
-    network_info_t *network = get_network();
+const char *get_network_name(void) {
+    const network_info_t *network = get_network();
     if (network == NULL) {
         return NULL;
     } else {
-        return (char *) PIC(network->name);
+        return (const char *) PIC(network->name);
     }
 }
 
-char *get_network_ticker(void) {
-    network_info_t *network = get_network();
+const char *get_network_ticker(void) {
+    const network_info_t *network = get_network();
     if (network == NULL) {
         return chainConfig->coinName;
     } else {

--- a/src_common/network.h
+++ b/src_common/network.h
@@ -13,8 +13,8 @@ typedef struct network_info_s {
 // Returns the current chain id. Defaults to 0 if txType was not found.
 uint64_t get_chain_id(void);
 // Returns a pointer to the network struct, or NULL if there is none.
-network_info_t *get_network(void);
+const network_info_t *get_network(void);
 // Returns a pointer to the network name, or NULL if there is none.
-char *get_network_name(void);
+const char *get_network_name(void);
 // Returns a pointer to the network ticker, or chainConfig->coinName if there is none.
-char *get_network_ticker(void);
+const char *get_network_ticker(void);

--- a/src_features/signTx/logic_signTx.c
+++ b/src_features/signTx/logic_signTx.c
@@ -214,7 +214,7 @@ static void computeFees(txInt256_t *BEgasPrice, txInt256_t *BEgasLimit, uint256_
 }
 
 static void feesToString(uint256_t *rawFee, char *displayBuffer, uint32_t displayBufferSize) {
-    char *feeTicker = get_network_ticker();
+    const char *feeTicker = get_network_ticker();
     uint8_t tickerOffset = 0;
     uint32_t i;
 
@@ -261,7 +261,7 @@ void prepareFeeDisplay() {
 }
 
 void prepareNetworkDisplay() {
-    char *name = get_network_name();
+    const char *name = get_network_name();
     if (name == NULL) {
         // No network name found so simply copy the chain ID as the network name.
         uint64_t chain_id = get_chain_id();
@@ -296,7 +296,7 @@ static void get_public_key(uint8_t *out, uint8_t outLength) {
 void finalizeParsing(bool direct) {
     char displayBuffer[50];
     uint8_t decimals = WEI_TO_ETHER;
-    char *ticker = get_network_ticker();
+    const char *ticker = get_network_ticker();
     ethPluginFinalize_t pluginFinalize;
     bool genericUI = true;
 

--- a/src_plugins/starkware/starkware_plugin.c
+++ b/src_plugins/starkware/starkware_plugin.c
@@ -185,7 +185,7 @@ bool is_deversify_contract(const uint8_t *address) {
 }
 
 // TODO : rewrite as independant code
-bool starkware_verify_asset_id(uint8_t *tmp32, uint8_t *tokenId, bool assetTypeOnly) {
+bool starkware_verify_asset_id(uint8_t *tmp32, const uint8_t *tokenId, bool assetTypeOnly) {
     if (quantumSet) {
         cx_sha3_t sha3;
         tokenDefinition_t *currentToken = NULL;
@@ -214,7 +214,7 @@ bool starkware_verify_asset_id(uint8_t *tmp32, uint8_t *tokenId, bool assetTypeO
     return true;
 }
 
-bool starkware_verify_token(uint8_t *token) {
+bool starkware_verify_token(const uint8_t *token) {
     if (quantumSet) {
         if (dataContext.tokenContext.quantumIndex != MAX_ITEMS) {
             tokenDefinition_t *currentToken =
@@ -235,7 +235,7 @@ bool starkware_verify_token(uint8_t *token) {
     return true;
 }
 
-bool starkware_verify_quantum(uint8_t *quantum) {
+bool starkware_verify_quantum(const uint8_t *quantum) {
     if (quantumSet) {
         if (dataContext.tokenContext.quantumIndex != MAX_ITEMS) {
             if (memcmp(quantum, dataContext.tokenContext.quantum, 32) != 0) {
@@ -254,7 +254,7 @@ bool starkware_verify_quantum(uint8_t *quantum) {
     return true;
 }
 
-bool starkware_verify_nft_token_id(uint8_t *tokenId) {
+bool starkware_verify_nft_token_id(const uint8_t *tokenId) {
     if (!quantumSet) {
         PRINTF("Quantum not set\n");
         return false;


### PR DESCRIPTION
- Mark read-only parameters given to plugins as `const`. This is better for both documentation and automated static analysis.
- Define better prototypes for "network" functions. All these functions return `const` objects. `const` qualifiers have been added in the function prototypes that return such objects.
- Change the prototype of `amountToString`. When used "normally", this function always triggers warnings by static analyzers as it takes a `uint8_t` as a size parameter.

It is usually called like this, where `msg->msgLength` is a `uint32_t`:

```c
amountToString(eth_amount, eth_amount_size, WEI_TO_ETHER, "ETH ", msg->msg, msg->msgLength);
```
or like this:
```c
amountToString(eth_amount, eth_amount_size, WEI_TO_ETHER, "ETH ", msg, sizeof(msg));
```

In both cases, a possible truncation is detected by static analyzers, although the function is able to handle bigger buffers. Currently, function will fail if an output buffer of 257 (0x101) bytes is provided, which makes no sense.
