### PR TITLE
[add] SDK submodule updated to develop + will now be auto updated

### DIFF
--- a/.github/actions/commit-changes/action.yml
+++ b/.github/actions/commit-changes/action.yml
@@ -38,6 +38,7 @@ runs:
   using: 'composite'
   steps:
     - name: Commit the changes
+      id: commit
       run: |
         git config --global user.name ${{ inputs.name }}
         ORIGIN="$(pwd)"
@@ -48,17 +49,20 @@ runs:
         if [ -z "${CHANGES}" ]; \
         then \
           echo "No changes, stopping now"; \
-          cd ${origin} \
+          echo "::save-state name=COMMIT::NO"; \
+          cd "${ORIGIN}"; \
           exit 0; \
         fi
         echo -e "Changes:\n${CHANGES}"
         git add ${{ inputs.files }}
         git commit -am "${{ inputs.message }}"
+        echo "::save-state name=COMMIT::YES"
         git log -n 2
-        cd ${ORIGIN}
+        cd "${ORIGIN}"
       shell: bash
 
     - name: Push commit
+      if: ${{ steps.commit.state.COMMIT == 'YES' }}
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ inputs.secret }}

--- a/.github/workflows/sdk-generation.yml
+++ b/.github/workflows/sdk-generation.yml
@@ -41,3 +41,13 @@ jobs:
           message: "[update] Branch ${{ steps.extract_branch.outputs.branch }} | Commit ${GITHUB_SHA}"
           secret: ${{ secrets.CI_BOT_TOKEN }}
           repository: LedgerHQ/ethereum-plugin-sdk
+
+      - name: Update the SDK submodule in the Ethereum app
+        uses: ./.github/actions/commit-changes
+        with:
+          name: 'ldg-github-ci'
+          files: ethereum-plugin-sdk
+          branch: ${{ steps.extract_branch.outputs.branch }}
+          message: "[update][SDK] Branch ${{ steps.extract_branch.outputs.branch }} | Commit ${GITHUB_SHA}"
+          secret: ${{ secrets.CI_BOT_TOKEN }}
+          repository: LedgerHQ/ethereum-plugin-sdk


### PR DESCRIPTION
## Description

This PR updates the SDK submodule, and also adds the automatic update of the Ethereum repository when the SDK submodule is automatically updated.

The SDK CI flow when merging on `develop` or `master` should now be:

- Generate the new SDK with `tools/build_sdk.py` (_old behavior_)
- If the SDK changes, creates and pushes a commit **in the SDK repository** with the changes on the related branch (`develop` or `master`) (_old behavior_)
- If the SDK changes, creates and pushes a commit **in the Ethereum repository** with the update SDK submodule on the related branch (`develop` or `master`) (_added by this PR_) 

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)