### PR TITLE
[add] Extending the amount buffer from 30 to 50 bytes

### DIFF
--- a/src/handle_check_address.c
+++ b/src/handle_check_address.c
@@ -16,7 +16,7 @@ int handle_check_address(check_address_parameters_t* params, chain_config_t* cha
     }
 
     uint8_t i;
-    uint8_t* bip32_path_ptr = params->address_parameters;
+    const uint8_t* bip32_path_ptr = params->address_parameters;
     uint8_t bip32PathLength = *(bip32_path_ptr++);
     cx_sha3_t local_sha3;
 

--- a/src/swap_lib_calls.h
+++ b/src/swap_lib_calls.h
@@ -11,17 +11,19 @@
 
 #define GET_PRINTABLE_AMOUNT 4
 
+#define MAX_PRINTABLE_AMOUNT_SIZE 50
+
 // structure that should be send to specific coin application to get address
 typedef struct check_address_parameters_s {
     // IN
-    unsigned char* coin_configuration;
-    unsigned char coin_configuration_length;
+    const unsigned char* const coin_configuration;
+    const unsigned char coin_configuration_length;
     // serialized path, segwit, version prefix, hash used, dictionary etc.
     // fields and serialization format depends on spesific coin app
-    unsigned char* address_parameters;
-    unsigned char address_parameters_length;
-    char* address_to_check;
-    char* extra_id_to_check;
+    const unsigned char* const address_parameters;
+    const unsigned char address_parameters_length;
+    const char* const address_to_check;
+    const char* const extra_id_to_check;
     // OUT
     int result;
 } check_address_parameters_t;
@@ -29,25 +31,25 @@ typedef struct check_address_parameters_s {
 // structure that should be send to specific coin application to get printable amount
 typedef struct get_printable_amount_parameters_s {
     // IN
-    unsigned char* coin_configuration;
-    unsigned char coin_configuration_length;
-    unsigned char* amount;
-    unsigned char amount_length;
-    bool is_fee;
+    const unsigned char* const coin_configuration;
+    const unsigned char coin_configuration_length;
+    const unsigned char* const amount;
+    const unsigned char amount_length;
+    const bool is_fee;
     // OUT
-    char printable_amount[30];
+    char printable_amount[MAX_PRINTABLE_AMOUNT_SIZE];
     // int result;
 } get_printable_amount_parameters_t;
 
 typedef struct create_transaction_parameters_s {
-    unsigned char* coin_configuration;
-    unsigned char coin_configuration_length;
-    unsigned char* amount;
-    unsigned char amount_length;
-    unsigned char* fee_amount;
-    unsigned char fee_amount_length;
-    char* destination_address;
-    char* destination_address_extra_id;
+    const unsigned char* const coin_configuration;
+    const unsigned char coin_configuration_length;
+    const unsigned char* const amount;
+    const unsigned char amount_length;
+    const unsigned char* const fee_amount;
+    const unsigned char fee_amount_length;
+    const char* const destination_address;
+    const char* const destination_address_extra_id;
 } create_transaction_parameters_t;
 
 #endif  // _SWAP_LIB_CALLS_H_

--- a/src/utils.c
+++ b/src/utils.c
@@ -138,7 +138,7 @@ void amountToString(const uint8_t *amount,
     out_buffer[out_buffer_size - 1] = '\0';
 }
 
-bool parse_swap_config(uint8_t *config, uint8_t config_len, char *ticker, uint8_t *decimals) {
+bool parse_swap_config(const uint8_t *config, uint8_t config_len, char *ticker, uint8_t *decimals) {
     uint8_t ticker_len, offset = 0;
     if (config_len == 0) {
         return false;

--- a/src/utils.h
+++ b/src/utils.h
@@ -39,6 +39,6 @@ void amountToString(const uint8_t* amount,
                     char* out_buffer,
                     size_t out_buffer_size);
 
-bool parse_swap_config(uint8_t* config, uint8_t config_len, char* ticker, uint8_t* decimals);
+bool parse_swap_config(const uint8_t* config, uint8_t config_len, char* ticker, uint8_t* decimals);
 
 #endif  // _UTILS_H_


### PR DESCRIPTION
## Description

Exchange application can ask for amounts exceeding the buffer size. This PR extends the buffer from 30 to 50 bytes, allowing much bigger transactions.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

## Additional comments

This PR will need to be synced with the completion of [this PR on exchange](https://github.com/LedgerHQ/app-exchange/pull/41).