### PR TITLE
[ci][clean] Explicit source and destination branches when auto commit and push

### DIFF
--- a/.github/actions/commit-changes/action.yml
+++ b/.github/actions/commit-changes/action.yml
@@ -21,10 +21,14 @@ inputs:
     description: 'The directory in which the action will be performed'
     required: true
     default: '.'
-  branch:
-    description: 'Checkout (or create) on a specific branch before commit/push'
-    required: true
-    default: 'master'
+  src_branch:
+    description: 'Checkout (or create) a specific branch before commit/push. Defaults to current branch'
+    required: false
+    default: ''
+  dst_branch:
+    description: 'Push the created commit on a specific branch. Defaults to current branch'
+    required: false
+    default: ''
   secret:
     description: 'A token allowing to push the commit on the repository'
     required: true
@@ -43,38 +47,73 @@ runs:
         git config --global user.name ${{ inputs.name }}
         ORIGIN="$(pwd)"
         cd ${{ inputs.directory }}
-        git switch ${{ inputs.branch }} 2>/dev/null || git switch -c ${{ inputs.branch }}
+
+        CURRENT_BRANCH=${GITHUB_REF#refs/heads/};
+        # calculating source branch
+        if [ -n  "${{ inputs.src_branch }}" ]; \
+        then \
+          git switch ${{ inputs.src_branch }} 2>/dev/null || git switch -c ${{ inputs.src_branch }}; \
+          SRC_BRANCH=${{ inputs.src_branch }}; \
+        else \
+          SRC_BRANCH=`git branch --show-current`; \
+          if [ -z "$SRC_BRANCH" ]; \
+          then \
+            SRC_BRANCH=$CURRENT_BRANCH; \
+          fi \
+        fi
+
+        # calculating destination branch
+        if [ -n "${{ inputs.dst_branch }}" ]; \
+        then \
+          DST_BRANCH=${{ inputs.dst_branch }}; \
+        else \
+          DST_BRANCH=`git branch --show-current`; \
+          if [ -z "$DST_BRANCH" ]; \
+          then \
+            DST_BRANCH=$CURRENT_BRANCH; \
+          fi \
+        fi
+
         echo "-----------------------------------------------------------"
         echo "Initial repo status"
         git status
+        # checking changes, commit if needed
         CHANGES="$(git status --porcelain ${{ inputs.files }})"
-        if [ -z "${CHANGES}" ]; \
+        if [ -n "${CHANGES}" ]; \
         then \
+          echo -e "Changes:\n${CHANGES}"; \
+          git add ${{ inputs.files }}; \
           echo "-----------------------------------------------------------"; \
-          echo "No changes, stopping now"; \
-          echo "COMMIT=NO" > $GITHUB_ENV; \
-          cd "${ORIGIN}"; \
-          exit 0; \
+          echo "Repo status before commit"; \
+          git status; \
+          git commit -am "${{ inputs.message }}"; \
         fi
-        echo -e "Changes:\n${CHANGES}"
-        git add ${{ inputs.files }}
-        echo "-----------------------------------------------------------"
-        echo "Repo status before commit"
-        git status
-        git commit -am "${{ inputs.message }}"
-        echo "COMMIT=YES" > $GITHUB_ENV
+
+        # compute if a push is needed
+        if [ -n "${CHANGES}" -o "$SRC_BRANCH" != "$DST_BRANCH" ]; \
+        then \
+          PUSH="YES"; \
+        else \
+          PUSH="NO"; \
+        fi
+
         git log -n 2
         cd "${ORIGIN}"
-      shell: bash
 
-    - run: echo "${{ env.COMMIT }}"
+        echo " -- Env SRC_BRANCH: $SRC_BRANCH";
+        echo " -- Env DST_BRANCH: $DST_BRANCH";
+        echo " -- Env PUSH: $PUSH"
+        # exporting these variables for next steps
+        echo "##[set-output name=src_branch;]$(echo $SRC_BRANCH)";
+        echo "##[set-output name=dst_branch;]$(echo $DST_BRANCH)";
+        echo "##[set-output name=push;]$(echo $PUSH)";
       shell: bash
 
     - name: Push commit
-      if: ${{ env.COMMIT == 'YES' }}
+      if: steps.commit.outputs.push == 'YES'
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ inputs.secret }}
-        branch: ${{ inputs.branch }}
+        branch: ${{ steps.commit.outputs.src_branch }}:${{ steps.commit.outputs.dst_branch }}
         directory: ${{ inputs.directory }}
         repository: ${{ inputs.repository }}

--- a/.github/workflows/sdk-generation.yml
+++ b/.github/workflows/sdk-generation.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           name: 'ldg-github-ci'
           directory: ethereum-plugin-sdk
-          branch: ${{ steps.extract_branch.outputs.branch }}
+          dst_branch: ${{ steps.extract_branch.outputs.branch }}
           message: "[update] Branch ${{ steps.extract_branch.outputs.branch }} | Commit ${GITHUB_SHA}"
           secret: ${{ secrets.CI_BOT_TOKEN }}
           repository: LedgerHQ/ethereum-plugin-sdk
@@ -47,7 +47,6 @@ jobs:
         with:
           name: 'ldg-github-ci'
           files: ethereum-plugin-sdk
-          branch: ${{ steps.extract_branch.outputs.branch }}
           message: "[update][SDK] Branch ${{ steps.extract_branch.outputs.branch }} | Commit ${GITHUB_SHA}"
           secret: ${{ secrets.CI_BOT_TOKEN }}
           repository: LedgerHQ/app-ethereum


### PR DESCRIPTION
... so that 'develop' SDK commits can be pushed to 'master' when merging.

## Description

Current SDK CI does not behave correctly: 

When merging from `develop` to `master`, SDK branch is also `develop`.
The SDK CI tries to update, commit and push the SDK. however, has all modification has been done in `develop`, there is nothing to commit and nothing is pushed or changed. So at the end the `master` of Ethereum points the `develop` branch on its SDK submodule.

We want the pointed branch to be `master`.

This branch remove the previous ambiguous `branch` input of the `commit-changes` custom action, and replaces it with `src_branch` and `dst_branch` inputs. These inputs are not required (in which case the fallback is current branch).

In our case, the `src_branch` is not defined - it is the current branch. However, when commiting changes inside the SDK, the `dst_branch` is defined as the current branch **of the Ethereum repository** (not the SDK current branch). So during a merge on Ethereum:
- from `whatever branch` to `develop`, the SDK should still be on `develop` (we are not expecting custom branches on the SDK), so the changes are pushed to the `develop` branch of the SDK
- from `develop` to `master`, the SDK should be on `develop` (as it comes from the Ethereum `develop` branch), and the changes will be pushed to the `master` branch of the SDK.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)