### PR TITLE
Security review

### DIFF
--- a/src_common/uint128.c
+++ b/src_common/uint128.c
@@ -242,6 +242,11 @@ bool tostring128(const uint128_t *const number,
         divmod128(&rDiv, &base, &rDiv, &rMod);
         out[offset++] = HEXDIGITS[(uint8_t) LOWER(rMod)];
     } while (!zero128(&rDiv));
+
+    if (offset > (outLength - 1)) {
+        return false;
+    }
+
     out[offset] = '\0';
     reverseString(out, offset);
     return true;

--- a/src_features/signMessageEIP712/context.c
+++ b/src_features/signMessageEIP712/context.c
@@ -14,6 +14,7 @@
 #include "shared_context.h"  // reset_app_context
 #include "ui_callbacks.h"    // ui_idle
 
+e_struct_init struct_state = NOT_INITIALIZED;
 s_eip712_context *eip712_context = NULL;
 
 /**
@@ -50,6 +51,8 @@ bool eip712_context_init(void) {
     {
         return false;
     }
+
+    struct_state = NOT_INITIALIZED;
 
     return true;
 }

--- a/src_features/signMessageEIP712/context.h
+++ b/src_features/signMessageEIP712/context.h
@@ -16,6 +16,9 @@ extern s_eip712_context *eip712_context;
 bool eip712_context_init(void);
 void eip712_context_deinit(void);
 
+typedef enum {NOT_INITIALIZED, INITIALIZED} e_struct_init;
+extern e_struct_init struct_state;
+
 #endif  // HAVE_EIP712_FULL_SUPPORT
 
 #endif  // EIP712_CTX_H_

--- a/src_features/signMessageEIP712/encode_field.c
+++ b/src_features/signMessageEIP712/encode_field.c
@@ -74,6 +74,11 @@ void *encode_uint(const uint8_t *const value, uint8_t length) {
 void *encode_int(const uint8_t *const value, uint8_t length, uint8_t typesize) {
     uint8_t padding_value;
 
+    if (length < 1) {
+        apdu_response_code = APDU_RESPONSE_INVALID_DATA;
+        return NULL; 
+    }
+
     if ((length == typesize) && (value[0] & (1 << 7)))  // negative number
     {
         padding_value = 0xFF;

--- a/src_features/signMessageEIP712/field_hash.c
+++ b/src_features/signMessageEIP712/field_hash.c
@@ -254,6 +254,11 @@ bool field_hash(const uint8_t *data, uint8_t data_length, bool partial) {
     field_type = struct_field_type(field_ptr);
     if (fh->state == FHS_IDLE)  // first packet for this frame
     {
+        if (data_length < 2) {
+            apdu_response_code = APDU_RESPONSE_INVALID_DATA;
+            return false;
+        }
+
         data = field_hash_prepare(field_ptr, data, &data_length);
     }
     if (data_length > fh->remaining_size) {

--- a/src_features/signMessageEIP712/path.c
+++ b/src_features/signMessageEIP712/path.c
@@ -21,10 +21,10 @@ static s_path *path_struct = NULL;
  *
  * @param[out] fields_count_ptr the number of fields in the last evaluated depth
  * @param[in] n the number of depths to evaluate
- * @return the feld which the first Nth depths points to
+ * @return the field which the first Nth depths points to
  */
 static const void *get_nth_field(uint8_t *const fields_count_ptr, uint8_t n) {
-    const void *struct_ptr = path_struct->root_struct;
+    const void *struct_ptr = NULL;
     const void *field_ptr = NULL;
     const char *typename;
     uint8_t length;
@@ -33,6 +33,9 @@ static const void *get_nth_field(uint8_t *const fields_count_ptr, uint8_t n) {
     if (path_struct == NULL) {
         return NULL;
     }
+
+    struct_ptr = path_struct->root_struct;
+
     if (n > path_struct->depth_count)  // sanity check
     {
         return NULL;


### PR DESCRIPTION
## Description

1. Fix  out of bounds write on tostring128().
2. Fix null pointer dereference on `set_struct_field()` on `*(typed_data->current_struct_fields_array) += 1`. It was possible to trigger this behavior by adding a field without defining a structure first. The fix was to implement a simple state, it is only possible to add a new field if a structure has been defined first.
3. When adding a field with a typesize, make sure it is not of type custom. Otherwise its possible to go out of bounds on the dynamic buffer, because of `get_next_struct_field()` implementation.
4. Added missing checks before accessing the data buffer (`encode_int`, `field_hash`).
5. On `set_struct_field_array()` there is a 4 byte write into a 1 byte buffer. The buffer is allocated in ` if ((array_level = mem_alloc(sizeof(uint8_t))) == NULL) ` as a `uint8_t` but `sizeof(e_array_type) = 4` (not fixed).
6. The variables that keep track of how many structs and fields currently exist are subject to integer overflow, which can result in loss of information, `current_struct_fields_array` and `structs_array` should have a maximum value to avoid this issue (not fixed).

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
