### PR TITLE
Abort signing process ETH_PLUGIN_QUERY_*

### DIFF
--- a/src/eth_plugin_handler.c
+++ b/src/eth_plugin_handler.c
@@ -348,13 +348,13 @@ eth_plugin_result_t eth_plugin_call(int method, void *parameter) {
             }
             break;
         case ETH_PLUGIN_QUERY_CONTRACT_ID:
-            if (((ethQueryContractID_t *) parameter)->result <= ETH_PLUGIN_RESULT_UNSUCCESSFUL) {
-                return ETH_PLUGIN_RESULT_UNAVAILABLE;
+            if (((ethQueryContractID_t *) parameter)->result != ETH_PLUGIN_RESULT_OK) {
+                return ETH_PLUGIN_RESULT_ERROR;
             }
             break;
         case ETH_PLUGIN_QUERY_CONTRACT_UI:
-            if (((ethQueryContractUI_t *) parameter)->result <= ETH_PLUGIN_RESULT_UNSUCCESSFUL) {
-                return ETH_PLUGIN_RESULT_UNAVAILABLE;
+            if (((ethQueryContractUI_t *) parameter)->result != ETH_PLUGIN_RESULT_OK) {
+                return ETH_PLUGIN_RESULT_ERROR;
             }
             break;
         default:


### PR DESCRIPTION
Before was not possible to abort the signing process even if the plugin return an error code. According to the docs any return code besides ETH_PLUGIN_RESULT_OK should abort the signing process.

## Description

Please provide a detailed description of what was done in this PR.  
(And mentioned if linked to an issue [docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
