### PR TITLE
Eip712 review

### DIFF
--- a/src_features/signMessageEIP712/commands_712.c
+++ b/src_features/signMessageEIP712/commands_712.c
@@ -49,7 +49,7 @@ void handle_eip712_return_code(bool success) {
 bool handle_eip712_struct_def(const uint8_t *const apdu_buf) {
     bool ret = true;
 
-    if (eip712_context == NULL) {
+    if (eip712_context == NULL || struct_state == DEFINED) {
         ret = eip712_context_init();
     }
     if (ret) {

--- a/src_features/signMessageEIP712/commands_712.c
+++ b/src_features/signMessageEIP712/commands_712.c
@@ -49,9 +49,14 @@ void handle_eip712_return_code(bool success) {
 bool handle_eip712_struct_def(const uint8_t *const apdu_buf) {
     bool ret = true;
 
-    if (eip712_context == NULL || struct_state == DEFINED) {
+    if (eip712_context == NULL) {
         ret = eip712_context_init();
     }
+
+    if (struct_state == DEFINED) {
+        ret = false;
+    }
+
     if (ret) {
         switch (apdu_buf[OFFSET_P2]) {
             case P2_DEF_NAME:

--- a/src_features/signMessageEIP712/context_712.h
+++ b/src_features/signMessageEIP712/context_712.h
@@ -17,7 +17,7 @@ extern s_eip712_context *eip712_context;
 bool eip712_context_init(void);
 void eip712_context_deinit(void);
 
-typedef enum { NOT_INITIALIZED, INITIALIZED } e_struct_init;
+typedef enum { NOT_INITIALIZED, INITIALIZED, DEFINED } e_struct_init;
 extern e_struct_init struct_state;
 
 #endif  // HAVE_EIP712_FULL_SUPPORT

--- a/src_features/signMessageEIP712/path.c
+++ b/src_features/signMessageEIP712/path.c
@@ -363,6 +363,8 @@ bool path_set_root(const char *const struct_name, uint8_t name_length) {
         path_struct->root_type = ROOT_MESSAGE;
     }
 
+    struct_state = DEFINED;
+
     // because the first field could be a struct type
     path_update();
     return true;


### PR DESCRIPTION
## Description

It is possible to send a new structure definition after sending a structure implementation, which makes the app treat unrestricted data as if it was a well defined structure.
This commit tries to fix that behavior. Once a structure implementation is sent, we consider all structures to be defined and we do not allow new definitions

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)