### PR TITLE
Fix potential crash with slow APDU transport

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -209,7 +209,7 @@ jobs:
           cd tests/ragger
           python3 -m venv ./venv
           . ./venv/bin/activate
-          pip3 install --extra-index-url https://test.pypi.org/simple/ -r requirements.txt speculos
+          pip3 install --extra-index-url https://test.pypi.org/simple/ -r requirements.txt
           # Used for the cache key
           echo "py_deps=$(pip freeze | md5sum | cut -d' ' -f1)" >> $GITHUB_ENV
 
@@ -275,4 +275,4 @@ jobs:
         run: |
           cd tests/ragger
           . ./venv/bin/activate
-          pytest --path ./elfs --model ${{ matrix.model }}
+          pytest --path ./elfs --model ${{ matrix.model }} -s -v

--- a/src_bagl/ui_flow_signMessage712.c
+++ b/src_bagl/ui_flow_signMessage712.c
@@ -16,6 +16,10 @@ static void dummy_cb(void) {
             ux_flow_prev();
             ui_pos = UI_712_POS_REVIEW;
         }
+    } else {
+        // temporarily disable button clicks, they will be re-enabled as soon as new data
+        // is received and the page is redrawn with ux_flow_init()
+        G_ux.stack[0].button_push_callback = NULL;
     }
 }
 

--- a/tests/ragger/ethereum_client/client.py
+++ b/tests/ragger/ethereum_client/client.py
@@ -7,6 +7,7 @@ from ethereum_client.setting import SettingType, SettingImpl
 from ethereum_client.eip712 import EIP712FieldType
 from ethereum_client.response_parser import EthereumRespParser
 import signal
+import time
 
 
 class   EthereumClient:
@@ -92,6 +93,7 @@ class   EthereumClient:
 
     def eip712_sign_new(self, bip32):
         with self._send(self._cmd_builder.eip712_sign_new(bip32)):
+            time.sleep(0.5) # tight on timing, needed by the CI otherwise might fail sometimes
             if not self._settings[SettingType.VERBOSE_EIP712].value and \
                not self._eip712_filtering: # need to skip the message hash
                 self._client.right_click()


### PR DESCRIPTION
## Description

The [dummy UX_STEP](https://github.com/LedgerHQ/app-ethereum/blob/1.10.0/src_bagl/ui_flow_signMessage712.c#L39-L46) was not protected against the user clicking on it.
Over USB HID, this was not really an issue as the APDUs arrive very fast and even spamming the right button would only get the user to the "Approve" screen for a fraction of a second, resulting in a small visual glitch but nothing more.
Over a slow transport like Bluetooth the user would be able to do multiple clicks even at a normal speed, and once on the "Approve" screen clicking left would result in an instant crash of the application/device.

The solution was to entirely disable button clicks on the dummy screen while the app is waiting for more APDUs.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)