### PR TITLE
[fix] 'github-push-action' does not seem to cope with src:dst git push syntax

### DIFF
--- a/.github/actions/commit-changes/action.yml
+++ b/.github/actions/commit-changes/action.yml
@@ -114,6 +114,6 @@ runs:
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ inputs.secret }}
-        branch: ${{ steps.commit.outputs.src_branch }}:${{ steps.commit.outputs.dst_branch }}
+        branch: ${{ steps.commit.outputs.dst_branch }}
         directory: ${{ inputs.directory }}
         repository: ${{ inputs.repository }}


### PR DESCRIPTION
## Description

Please provide a detailed description of what was done in this PR.  
(And mentioned if linked to an issue [docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.