### PR TITLE
EIP-712 verbose mode fix

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -955,6 +955,9 @@ void coin_main(chain_config_t *coin_config) {
 #endif
                     storage.contractDetails = 0x00;
                     storage.displayNonce = 0x00;
+#ifdef HAVE_EIP712_FULL_SUPPORT
+                    storage.verbose_eip712 = 0x00;
+#endif
                     storage.initialized = 0x01;
                     nvm_write((void *) &N_storage, (void *) &storage, sizeof(internalStorage_t));
                 }

--- a/src_bagl/ui_flow_signMessage712.c
+++ b/src_bagl/ui_flow_signMessage712.c
@@ -7,19 +7,25 @@ enum { UI_712_POS_REVIEW, UI_712_POS_END };
 static uint8_t ui_pos;
 
 static void dummy_cb(void) {
-    if (!ui_712_next_field()) {
-        if (ui_pos == UI_712_POS_REVIEW) {
-            ux_flow_next();
-            ui_pos = UI_712_POS_END;
-        } else  // UI_712_POS_END
-        {
-            ux_flow_prev();
-            ui_pos = UI_712_POS_REVIEW;
-        }
-    } else {
-        // temporarily disable button clicks, they will be re-enabled as soon as new data
-        // is received and the page is redrawn with ux_flow_init()
-        G_ux.stack[0].button_push_callback = NULL;
+    switch (ui_712_next_field()) {
+        case EIP712_NO_MORE_FIELD:
+            if (ui_pos == UI_712_POS_REVIEW) {
+                ux_flow_next();
+                ui_pos = UI_712_POS_END;
+            } else  // UI_712_POS_END
+            {
+                ux_flow_prev();
+                ui_pos = UI_712_POS_REVIEW;
+            }
+            break;
+        case EIP712_FIELD_INCOMING:
+            // temporarily disable button clicks, they will be re-enabled as soon as new data
+            // is received and the page is redrawn with ux_flow_init()
+            G_ux.stack[0].button_push_callback = NULL;
+            break;
+        case EIP712_FIELD_LATER:
+        default:
+            break;
     }
 }
 

--- a/src_features/signMessageEIP712/ui_logic.c
+++ b/src_features/signMessageEIP712/ui_logic.c
@@ -115,10 +115,12 @@ void ui_712_redraw_generic_step(void) {
 /**
  * Called to fetch the next field if they have not all been processed yet
  *
- * @return whether there will be a next field
+ * Also handles the special "Review struct" screen of the verbose mode
+ *
+ * @return the next field state
  */
-bool ui_712_next_field(void) {
-    bool next = false;
+e_eip712_nfs ui_712_next_field(void) {
+    e_eip712_nfs state = EIP712_NO_MORE_FIELD;
 
     if (ui_ctx == NULL) {
         apdu_response_code = APDU_RESPONSE_CONDITION_NOT_SATISFIED;
@@ -126,13 +128,13 @@ bool ui_712_next_field(void) {
         if (ui_ctx->structs_to_review > 0) {
             ui_712_review_struct(path_get_nth_field_to_last(ui_ctx->structs_to_review));
             ui_ctx->structs_to_review -= 1;
-        }
-        if (!ui_ctx->end_reached) {
+            state = EIP712_FIELD_LATER;
+        } else if (!ui_ctx->end_reached) {
             handle_eip712_return_code(true);
-            next = true;
+            state = EIP712_FIELD_INCOMING;
         }
     }
-    return next;
+    return state;
 }
 
 /**

--- a/src_features/signMessageEIP712/ui_logic.h
+++ b/src_features/signMessageEIP712/ui_logic.h
@@ -10,6 +10,11 @@
 #define UI_712_FIELD_NAME_PROVIDED (1 << 1)
 
 typedef enum { EIP712_FILTERING_BASIC, EIP712_FILTERING_FULL } e_eip712_filtering_mode;
+typedef enum {
+    EIP712_FIELD_LATER,
+    EIP712_FIELD_INCOMING,
+    EIP712_NO_MORE_FIELD
+} e_eip712_nfs;  // next field state
 
 typedef struct {
     bool shown;
@@ -22,7 +27,7 @@ typedef struct {
 
 bool ui_712_init(void);
 void ui_712_deinit(void);
-bool ui_712_next_field(void);
+e_eip712_nfs ui_712_next_field(void);
 void ui_712_review_struct(const void *const struct_ptr);
 bool ui_712_new_field(const void *const field_ptr, const uint8_t *const data, uint8_t length);
 void ui_712_end_sign(void);

--- a/tests/ragger/eip712/InputData.py
+++ b/tests/ragger/eip712/InputData.py
@@ -21,7 +21,7 @@ sig_ctx = {}
 # Output = ('uint8', [2, None, 4])  |   ('bool', [])
 def get_array_levels(typename):
     array_lvls = list()
-    regex = re.compile("(.*)\[([0-9]*)\]$")
+    regex = re.compile(r"(.*)\[([0-9]*)\]$")
 
     while True:
         result = regex.search(typename)
@@ -42,7 +42,7 @@ def get_array_levels(typename):
 # Input  = "uint64"         |   "string"
 # Output = ('uint', 64)     |   ('string', None)
 def get_typesize(typename):
-    regex = re.compile("^(\w+?)(\d*)$")
+    regex = re.compile(r"^(\w+?)(\d*)$")
     result = regex.search(typename)
     typename = result.group(1)
     typesize = result.group(2)


### PR DESCRIPTION
## Description

Introduced by the EIP-712 UI split c158c3e5, there was an issue in the EIP712 verbose mode with the "Review struct" screen, it would display it for a fraction of a second then instantly go to the next screen by itself.
The signature process was still working other than this small visual glitch.

It was replying to the last APDU too early, it now properly waits for all the pending "Review struct" screens to be seen by the user before it replies which triggers the next APDU to come in and show the next field.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)