### PR TITLE
Add KCC Chain with ChainID = 321 as ETH clones

### DIFF
--- a/src_common/network.c
+++ b/src_common/network.c
@@ -49,9 +49,9 @@ const network_info_t NETWORK_MAPPING[] = {
     {.chain_id = 19, .name = "Songbird", .ticker = "SGB "},
     {.chain_id = 73799, .name = "Volta", .ticker = "VOLTA "},
     {.chain_id = 25, .name = "Cronos", .ticker = "CRO "},
-    {.chain_id = 534352, .name = "Scroll", .ticker = "SCR "},
     {.chain_id = 534354, .name = "Scroll (Pre-Alpha)", .ticker = "SCR "},
     {.chain_id = 534353, .name = "Scroll (Goerli)", .ticker = "SCR "},
+    {.chain_id = 534352, .name = "Scroll", .ticker = "SCR "},
     {.chain_id = 321, .name = "KCC", .ticker = "KCS "}};
 
 uint64_t get_chain_id(void) {

--- a/src_common/network.c
+++ b/src_common/network.c
@@ -49,10 +49,10 @@ const network_info_t NETWORK_MAPPING[] = {
     {.chain_id = 19, .name = "Songbird", .ticker = "SGB "},
     {.chain_id = 73799, .name = "Volta", .ticker = "VOLTA "},
     {.chain_id = 25, .name = "Cronos", .ticker = "CRO "},
+    {.chain_id = 321, .name = "KCC", .ticker = "KCS "},
     {.chain_id = 534354, .name = "Scroll (Pre-Alpha)", .ticker = "SCR "},
     {.chain_id = 534353, .name = "Scroll (Goerli)", .ticker = "SCR "},
-    {.chain_id = 534352, .name = "Scroll", .ticker = "SCR "}},
-    {.chain_id = 321, .name = "KCC", .ticker = "KCS "}};
+    {.chain_id = 534352, .name = "Scroll", .ticker = "SCR "};
 
 uint64_t get_chain_id(void) {
     uint64_t chain_id = 0;

--- a/src_common/network.c
+++ b/src_common/network.c
@@ -49,10 +49,10 @@ const network_info_t NETWORK_MAPPING[] = {
     {.chain_id = 19, .name = "Songbird", .ticker = "SGB "},
     {.chain_id = 73799, .name = "Volta", .ticker = "VOLTA "},
     {.chain_id = 25, .name = "Cronos", .ticker = "CRO "},
-    {.chain_id = 321, .name = "KCC", .ticker = "KCS "},
+    {.chain_id = 534352, .name = "Scroll", .ticker = "SCR "},
     {.chain_id = 534354, .name = "Scroll (Pre-Alpha)", .ticker = "SCR "},
     {.chain_id = 534353, .name = "Scroll (Goerli)", .ticker = "SCR "},
-    {.chain_id = 534352, .name = "Scroll", .ticker = "SCR "}};
+    {.chain_id = 321, .name = "KCC", .ticker = "KCS "}};
 
 uint64_t get_chain_id(void) {
     uint64_t chain_id = 0;

--- a/src_common/network.c
+++ b/src_common/network.c
@@ -52,7 +52,7 @@ const network_info_t NETWORK_MAPPING[] = {
     {.chain_id = 321, .name = "KCC", .ticker = "KCS "},
     {.chain_id = 534354, .name = "Scroll (Pre-Alpha)", .ticker = "SCR "},
     {.chain_id = 534353, .name = "Scroll (Goerli)", .ticker = "SCR "},
-    {.chain_id = 534352, .name = "Scroll", .ticker = "SCR "};
+    {.chain_id = 534352, .name = "Scroll", .ticker = "SCR "}};
 
 uint64_t get_chain_id(void) {
     uint64_t chain_id = 0;

--- a/src_common/network.c
+++ b/src_common/network.c
@@ -48,7 +48,8 @@ const network_info_t NETWORK_MAPPING[] = {
     {.chain_id = 7341, .name = "Shyft", .ticker = "SHFT "},
     {.chain_id = 19, .name = "Songbird", .ticker = "SGB "},
     {.chain_id = 73799, .name = "Volta", .ticker = "VOLTA "},
-    {.chain_id = 25, .name = "Cronos", .ticker = "CRO "}};
+    {.chain_id = 25, .name = "Cronos", .ticker = "CRO "}},
+    {.chain_id = 321, .name = "KCC", .ticker = "KCS "}};
 
 uint64_t get_chain_id(void) {
     uint64_t chain_id = 0;

--- a/src_common/network.c
+++ b/src_common/network.c
@@ -48,7 +48,7 @@ const network_info_t NETWORK_MAPPING[] = {
     {.chain_id = 7341, .name = "Shyft", .ticker = "SHFT "},
     {.chain_id = 19, .name = "Songbird", .ticker = "SGB "},
     {.chain_id = 73799, .name = "Volta", .ticker = "VOLTA "},
-    {.chain_id = 25, .name = "Cronos", .ticker = "CRO "}},
+    {.chain_id = 25, .name = "Cronos", .ticker = "CRO "},
     {.chain_id = 534354, .name = "Scroll (Pre-Alpha)", .ticker = "SCR "},
     {.chain_id = 534353, .name = "Scroll (Goerli)", .ticker = "SCR "},
     {.chain_id = 534352, .name = "Scroll", .ticker = "SCR "}},


### PR DESCRIPTION
## Description

Addition of KCC(KUCOIN Chain) network as ETH clones.

- Homepage:  [https://kcc.io](https://kcc.io)
- Doc: [https://docs.kcc.io](https://docs.kcc.io)
- ChainID: 321
- Chainlist: [https://chainlist.org/chain/321](https://chainlist.org/chain/321)

## Changes include

- KCC