### PR TITLE
Add Venidium Network

### DIFF
--- a/src_common/network.c
+++ b/src_common/network.c
@@ -52,7 +52,8 @@ const network_info_t NETWORK_MAPPING[] = {
     {.chain_id = 534354, .name = "Scroll (Pre-Alpha)", .ticker = "SCR "},
     {.chain_id = 534353, .name = "Scroll (Goerli)", .ticker = "SCR "},
     {.chain_id = 534352, .name = "Scroll", .ticker = "SCR "},
-    {.chain_id = 321, .name = "KCC", .ticker = "KCS "}};
+    {.chain_id = 321, .name = "KCC", .ticker = "KCS "},
+    {.chain_id = 4919, .name = "Venidium", .ticker = "XVM "}};
 
 uint64_t get_chain_id(void) {
     uint64_t chain_id = 0;


### PR DESCRIPTION
## Description

Add Venidium Network to the Ethereum App

Homepage: https://venidium.io
Documentation: https://venidium.gitbook.io/start/technical-documentation-evm-dpos/chain-info
Chain ID: 4919
Chainlist: https://chainlist.org/chain/4919
slip-0044: https://github.com/satoshilabs/slips/blob/7132058e62af6ebf23ea8d06fd425beb0da8cb89/slip-0044.md?plain=1#L1153

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
