### PR TITLE
Fix EIP-191 regression

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -72,10 +72,10 @@ jobs:
 
       - run: sudo apt-get update -y && sudo apt-get install -y libusb-1.0.0 libudev-dev
 
-      - name: Install node
+      - name: Install NodeJS
         uses: actions/setup-node@v3
         with:
-          node-version: "14.4.0"
+          node-version: "16"
 
       - name: Install yarn
         run: npm install -g yarn

--- a/src_bagl/ui_flow_signMessage.c
+++ b/src_bagl/ui_flow_signMessage.c
@@ -18,10 +18,10 @@ static void dummy_pre_cb(void) {
 
 static void dummy_post_cb(void) {
     if (ui_pos == UI_191_POS_QUESTION) {
-        continue_displaying_message();
         // temporarily disable button clicks, they will be re-enabled as soon as new data
         // is received and the page is redrawn with ux_flow_init()
         G_ux.stack[0].button_push_callback = NULL;
+        continue_displaying_message();
     } else  // UI_191_END
     {
         ui_191_switch_to_message_end();

--- a/tests/speculos/conftest.py
+++ b/tests/speculos/conftest.py
@@ -9,8 +9,6 @@ from ethereum_client.ethereum_cmd import EthereumCommand
 SCRIPT_DIR = Path(__file__).absolute().parent
 API_URL = "http://127.0.0.1:5000"
 
-VERSION = {"nanos": "2.1", "nanox": "2.0.2", "nanosp": "1.0.3"}
-
 
 def pytest_addoption(parser):
     # nanos, nanox, nanosp
@@ -27,7 +25,7 @@ def client(pytestconfig):
     file_path = pytestconfig.getoption("path")
     model = pytestconfig.getoption("model")
 
-    args = ['--log-level', 'speculos:DEBUG','--model', model, '--display', pytestconfig.getoption("display"), '--sdk', VERSION[model]]
+    args = ['--log-level', 'speculos:DEBUG','--model', model, '--display', pytestconfig.getoption("display")]
     with SpeculosClient(app=str(file_path), args=args) as client:
         yield client
 


### PR DESCRIPTION
## Description

Button clicks were disabled after the event that was supposed to enable them back, instead of before. So the user would be left with an unresponsive app.
Introduced in #402 

Fixed Speculos tests to work with the the latest LNS+ & LNX releases.
Zemu tests are failing since it does not yet support the latest SDKs.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)