### PR TITLE
Update erc20 legder public key

### DIFF
--- a/doc/ethapp.adoc
+++ b/doc/ethapp.adoc
@@ -263,7 +263,7 @@ The signature is computed on
 
 ticker || address || number of decimals (uint4be) || chainId (uint4be)
 
-signed by the following secp256k1 public key 0482bbf2f34f367b2e5bc21847b6566f21f0976b22d3388a9a5e446ac62d25cf725b62a2555b2dd464a4da0ab2f4d506820543af1d242470b1b1a969a27578f353
+signed by the following secp256k1 public key 045e6c1020c14dc46442fe89f97c0b68cdb15976dc24f24c316e7b30fe4e8cc76b1489150c21514ebf440ff5dea5393d83de5358cd098fce8fd0f81daa94979183
 
 #### Coding
 


### PR DESCRIPTION
## Description

Updated public key used for signing token information in Provide ERC20 Information APDU

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [x] Documentation
- [ ] Other (for changes that might not fit in any category)


## Additional comments

This public key works with the latest cryptoassets signatures, but please double check.