### PR TITLE
Fat: INTER_REGULAR_32 is now INTER_MEDIUM_32

### DIFF
--- a/src_nbgl/ui_sign_712.c
+++ b/src_nbgl/ui_sign_712.c
@@ -36,7 +36,7 @@ static uint32_t stringsIdx = 0;
 static bool displayTransactionPage(uint8_t page, nbgl_pageContent_t *content) {
     uint16_t len = 0;
     if (stringsIdx < strlen(strings.tmp.tmp)) {
-        bool reached = nbgl_getTextMaxLenInNbLines(BAGL_FONT_INTER_REGULAR_32px,
+        bool reached = nbgl_getTextMaxLenInNbLines(BAGL_FONT_INTER_MEDIUM_32px,
                                                    strings.tmp.tmp + stringsIdx,
                                                    SCREEN_WIDTH - (2 * BORDER_MARGIN),
                                                    9,

--- a/src_nbgl/ui_sign_message.c
+++ b/src_nbgl/ui_sign_message.c
@@ -43,7 +43,7 @@ static bool nav_callback(uint8_t page, nbgl_pageContent_t *content) {
                 strings.tmp.tmp + stringsTmpTmpIdx,
                 MIN(SHARED_BUFFER_SIZE - eip191MessageIdx, SHARED_BUFFER_SIZE - stringsTmpTmpIdx));
             uint16_t len = 0;
-            bool reached = nbgl_getTextMaxLenInNbLines(BAGL_FONT_INTER_REGULAR_32px,
+            bool reached = nbgl_getTextMaxLenInNbLines(BAGL_FONT_INTER_MEDIUM_32px,
                                                        staxSharedBuffer,
                                                        SCREEN_WIDTH - (2 * BORDER_MARGIN),
                                                        9,


### PR DESCRIPTION
Replace BAGL_FONT_INTER_REGULAR_32px by BAGL_FONT_INTER_MEDIUM_32px. This change is valid starting from API_LEVEL_9

## Description

Please provide a detailed description of what was done in this PR.  
(And mentioned if linked to an issue [docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
