### PR TITLE
clean dataContext.tokenContext.data buffer between each plugin call...

### DIFF
--- a/src_features/signTx/logic_signTx.c
+++ b/src_features/signTx/logic_signTx.c
@@ -136,6 +136,7 @@ customStatus_e customProcessor(txContext_t *context) {
                 }
                 dataContext.tokenContext.fieldIndex++;
                 dataContext.tokenContext.fieldOffset = 0;
+                memset(dataContext.tokenContext.data, 0, sizeof(dataContext.tokenContext.data));
                 return CUSTOM_HANDLED;
             }
 


### PR DESCRIPTION
… to avoid unwanted data in last parameter when it isn't full length.

## Description

Fix #433
[issue](https://github.com/LedgerHQ/app-ethereum/issues/433)

Sanitize parameter's buffer (dataContext.tokenContext.data) between each plugin calls.