### PR TITLE
fix potential oob writes

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -131,15 +131,19 @@ void amountToString(const uint8_t *amount,
     uint8_t amount_len = strnlen(tmp_buffer, sizeof(tmp_buffer));
     uint8_t ticker_len = strnlen(ticker, MAX_TICKER_LEN);
 
-    memcpy(out_buffer, ticker, MIN(out_buffer_size, ticker_len));
-    if (ticker_len > 0) {
+    if (ticker_len > 0 && out_buffer_size > ticker_len + 1) {
+        memcpy(out_buffer, ticker, ticker_len);
         out_buffer[ticker_len++] = ' ';
+    }
+
+    if (out_buffer_size < ticker_len) {
+        return false;
     }
 
     if (adjustDecimals(tmp_buffer,
                        amount_len,
                        out_buffer + ticker_len,
-                       out_buffer_size - ticker_len - 1,
+                       out_buffer_size - ticker_len,
                        decimals) == false) {
         THROW(EXCEPTION_OVERFLOW);
     }

--- a/src/utils.c
+++ b/src/utils.c
@@ -137,7 +137,7 @@ void amountToString(const uint8_t *amount,
     }
 
     if (out_buffer_size < ticker_len) {
-        return false;
+        THROW(EXCEPTION_OVERFLOW);
     }
 
     if (adjustDecimals(tmp_buffer,


### PR DESCRIPTION
## Description

If there is a `ticker` available check if we can write the `ticker` and the empty space.
If the `ticker_len` is larger than `out_buffer_size` then buffer is full, return failure

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)