### PR TITLE
.gitmodules: Automatically access git submodules via ssh or https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ethereum-plugin-sdk"]
 	path = ethereum-plugin-sdk
-	url = git@github.com:LedgerHQ/ethereum-plugin-sdk.git
+	url = ../ethereum-plugin-sdk.git


### PR DESCRIPTION
## Description
Submodule URL was using ssh, so cloning with https resulted in cloning the submodule with SSH. 

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
