### PR TITLE
Update networks

### DIFF
--- a/src_common/network.c
+++ b/src_common/network.c
@@ -70,6 +70,7 @@ static const network_info_t NETWORK_MAPPING[] = {
     {.chain_id = 245022926, .name = "Neon EVM Devnet", .ticker = "NEON"},
     {.chain_id = 4919, .name = "Venidium", .ticker = "XVM"},
     {.chain_id = 40, .name = "Telos EVM Mainnet", .ticker = "TLOS"},
+    {.chain_id = 196, .name = "OKBChain Mainnet", .ticker = "OKB"},
     {.chain_id = 248, .name = "Oasys", .ticker = "OAS"}};
 
 static const network_info_t *get_network_from_chain_id(const uint64_t *chain_id) {

--- a/src_common/network.c
+++ b/src_common/network.c
@@ -68,10 +68,12 @@ static const network_info_t NETWORK_MAPPING[] = {
     {.chain_id = 39797, .name = "Energi", .ticker = "NRG"},
     {.chain_id = 369, .name = "PulseChain", .ticker = "PLS"},
     {.chain_id = 245022926, .name = "Neon EVM Devnet", .ticker = "NEON"},
+    {.chain_id = 245022934, .name = "Neon EVM Mainnet", .ticker = "NEON"},
     {.chain_id = 4919, .name = "Venidium", .ticker = "XVM"},
     {.chain_id = 40, .name = "Telos EVM Mainnet", .ticker = "TLOS"},
     {.chain_id = 196, .name = "OKBChain Mainnet", .ticker = "OKB"},
-    {.chain_id = 248, .name = "Oasys", .ticker = "OAS"}};
+    {.chain_id = 248, .name = "Oasys", .ticker = "OAS"},
+};
 
 static const network_info_t *get_network_from_chain_id(const uint64_t *chain_id) {
     for (size_t i = 0; i < ARRAYLEN(NETWORK_MAPPING); i++) {

--- a/src_common/network.c
+++ b/src_common/network.c
@@ -16,9 +16,11 @@ static const network_info_t NETWORK_MAPPING[] = {
     {.chain_id = 4, .name = "Rinkeby", .ticker = "ETH"},
     {.chain_id = 5, .name = "Goerli", .ticker = "ETH"},
     {.chain_id = 10, .name = "Optimism", .ticker = "ETH"},
-    {.chain_id = 42, .name = "Kovan", .ticker = "ETH"},
+    {.chain_id = 42, .name = "LUKSO", .ticker = "LYX"},
+    {.chain_id = 4201, .name = "LUKSO Testnet", .ticker = "LYXt"},
     {.chain_id = 56, .name = "BSC", .ticker = "BNB"},
-    {.chain_id = 100, .name = "xDai", .ticker = "xDAI"},
+    {.chain_id = 100, .name = "Gnosis", .ticker = "xDAI"},
+    {.chain_id = 10200, .name = "Chiado", .ticker = "xDAI"},
     {.chain_id = 137, .name = "Polygon", .ticker = "MATIC"},
     {.chain_id = 250, .name = "Fantom", .ticker = "FTM"},
     {.chain_id = 42161, .name = "Arbitrum", .ticker = "ETH"},
@@ -64,6 +66,9 @@ static const network_info_t NETWORK_MAPPING[] = {
     {.chain_id = 106, .name = "Velas EVM", .ticker = "VLX"},
     {.chain_id = 288, .name = "Boba Network", .ticker = "ETH"},
     {.chain_id = 39797, .name = "Energi", .ticker = "NRG"},
+    {.chain_id = 369, .name = "PulseChain", .ticker = "PLS"},
+    {.chain_id = 245022926, .name = "Neon EVM Devnet", .ticker = "NEON"},
+    {.chain_id = 4919, .name = "Venidium", .ticker = "XVM"},
     {.chain_id = 248, .name = "Oasys", .ticker = "OAS"}};
 
 static const network_info_t *get_network_from_chain_id(const uint64_t *chain_id) {

--- a/src_common/network.c
+++ b/src_common/network.c
@@ -69,6 +69,7 @@ static const network_info_t NETWORK_MAPPING[] = {
     {.chain_id = 369, .name = "PulseChain", .ticker = "PLS"},
     {.chain_id = 245022926, .name = "Neon EVM Devnet", .ticker = "NEON"},
     {.chain_id = 4919, .name = "Venidium", .ticker = "XVM"},
+    {.chain_id = 40, .name = "Telos EVM Mainnet", .ticker = "TLOS"},
     {.chain_id = 248, .name = "Oasys", .ticker = "OAS"}};
 
 static const network_info_t *get_network_from_chain_id(const uint64_t *chain_id) {


### PR DESCRIPTION
## Description

Added LUKSO and LUKSO Testnet : https://github.com/LedgerHQ/app-ethereum/pull/436

Added PulseChain : https://github.com/LedgerHQ/app-ethereum/pull/430

Added Neon Devnet : https://github.com/LedgerHQ/app-ethereum/pull/439 & mainnet

Adding Chiado and Renaming xDAI to Gnosis : https://github.com/LedgerHQ/app-ethereum/pull/422

Added Venidium : https://github.com/LedgerHQ/app-ethereum/pull/382

Added Telos

Added OKB

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Additional comments

All new networks are listed on https://chainlist.org/