### PR TITLE
Fix get_tx_chain_id() implicit declaration warnings

### DIFF
--- a/src_bagl/ui_flow_signTx.c
+++ b/src_bagl/ui_flow_signTx.c
@@ -7,6 +7,7 @@
 #include "eth_plugin_handler.h"
 #include "ui_plugin.h"
 #include "common_ui.h"
+#include "ethUtils.h"
 #include "plugins.h"
 #include "domain_name.h"
 #include "ui_domain_name.h"


### PR DESCRIPTION
## Description

Introduced by 34ea137c1a1e997580163e3b20ca74ddbb2d9e83

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)