### PR TITLE
Add a PRINTF of amounts in ERR_SILENT_MODE_CHECK_FAILED

### DIFF
--- a/src_features/signTx/logic_signTx.c
+++ b/src_features/signTx/logic_signTx.c
@@ -473,6 +473,8 @@ void finalizeParsing(bool direct) {
             // Ensure the values are the same that the ones that have been previously validated
             if (strcmp(strings.common.fullAmount, displayBuffer) != 0) {
                 PRINTF("ERR_SILENT_MODE_CHECK_FAILED, amount check failed\n");
+                PRINTF("Expected %s\n", strings.common.fullAmount);
+                PRINTF("Received %s\n", displayBuffer);
                 THROW(ERR_SILENT_MODE_CHECK_FAILED);
             }
         } else {


### PR DESCRIPTION
## Description

Add a PRINTF of amounts in ERR_SILENT_MODE_CHECK_FAILED

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [X] Other (for changes that might not fit in any category)
