### PR TITLE
feat: update Astar EVM name

### DIFF
--- a/makefile_conf/chain/astar.mk
+++ b/makefile_conf/chain/astar.mk
@@ -1,4 +1,4 @@
 APP_LOAD_PARAMS += --path "44'/810'" --path "44'/60'"
 TICKER = "ASTR"
 CHAIN_ID = 592
-APPNAME = "Astar EVM"
+APPNAME = "Astar Polkadot EVM"


### PR DESCRIPTION
## Description

Update display name of Astar EVM to "Astar Polkadot EVM".
Context: Astar has launched zkEVM rollup, and we want to make a clearer distinction from the Polkadot based Astar EVM chain.

## Changes include

- [x] rename "Astar EVM" to "Astar Polkadot EVM" in `astar.mk` file.
