### PR TITLE
Add a workaround for Github API refusing to open PRs too quickly

### DIFF
--- a/.github/workflows/pr_on_all_plugins.yml
+++ b/.github/workflows/pr_on_all_plugins.yml
@@ -136,6 +136,7 @@ jobs:
           github_token: ${{ secrets.CI_BOT_TOKEN }}
           branch: ${{ steps.commit-changes.outputs.branch_name }}
           repository: LedgerHQ/${{ matrix.repo }}
+          force: true
 
       - name: Create 'auto' label if missing
         run: |
@@ -145,6 +146,9 @@ jobs:
 
       - name: Create pull request and commment on SDK issue
         run: |
+          # Github limits the number of possible PR being opened in a given time window.
+          # As suggested in the Github documentation, put a 1 second sleep between each POST call
+          sleep ${{ strategy.job-index }}
           # Create the PR with a placeholder body. Will be consolidated at a later step
           pr_url=$(gh pr create \
                      --base 'develop' \


### PR DESCRIPTION
## Description

Add a workaround for Github API refusing to open PRs too quickly

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
