### PR TITLE
Fix incorrect assumption on max possible chain ID size

### DIFF
--- a/src/shared_context.h
+++ b/src/shared_context.h
@@ -176,14 +176,15 @@ typedef enum {
 #endif
 } contract_call_t;
 
-#define NETWORK_STRING_MAX_SIZE 16
+// must be able to hold in decimal up to : floor(MAX_UINT64 / 2) - 36
+#define NETWORK_STRING_MAX_SIZE 19
 
 typedef struct txStringProperties_s {
     char fullAddress[43];
     char fullAmount[79];  // 2^256 is 78 digits long
     char maxFee[50];
     char nonce[8];  // 10M tx per account ought to be enough for everybody
-    char network_name[NETWORK_STRING_MAX_SIZE];
+    char network_name[NETWORK_STRING_MAX_SIZE + 1];
 } txStringProperties_t;
 
 #ifdef TARGET_NANOS


### PR DESCRIPTION
## Description

Would make transactions with very large (but still within [specs](https://github.com/xinbenlv/EIPs/blob/master/EIPS/eip-2294.md)) chain IDs be refused by the device.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)