### PR TITLE
Return to Exchange when failing to sign in swap mode

### DIFF
--- a/src/handle_swap_sign_transaction.c
+++ b/src/handle_swap_sign_transaction.c
@@ -80,6 +80,7 @@ void handle_swap_sign_transaction(chain_config_t* config) {
     chainConfig = config;
     reset_app_context();
     G_called_from_swap = true;
+    G_swap_response_ready = false;
     io_seproxyhal_init();
 
     if (N_storage.initialized != 0x01) {

--- a/src/shared_context.h
+++ b/src/shared_context.h
@@ -215,6 +215,7 @@ extern cx_sha3_t global_sha3;
 extern const internalStorage_t N_storage_real;
 
 extern bool G_called_from_swap;
+extern bool G_swap_response_ready;
 
 typedef enum {
     EXTERNAL,     //  External plugin, set by setExternalPlugin.

--- a/src_features/signTx/logic_signTx.c
+++ b/src_features/signTx/logic_signTx.c
@@ -433,6 +433,15 @@ void finalizeParsing(bool direct) {
         }
     }
 
+    if (G_called_from_swap) {
+        if (G_swap_response_ready) {
+            // Unreachable given current return to exchange mechanism. Safeguard against regression
+            PRINTF("FATAL: safety against double sign triggered\n");
+            os_sched_exit(-1);
+        }
+        G_swap_response_ready = true;
+    }
+
     // User has just validated a swap but ETH received apdus about a non standard plugin / contract
     if (G_called_from_swap && !use_standard_UI) {
         PRINTF("ERR_SILENT_MODE_CHECK_FAILED, G_called_from_swap\n");
@@ -504,6 +513,8 @@ void finalizeParsing(bool direct) {
         // Ensure the values are the same that the ones that have been previously validated
         if (strcmp(strings.common.maxFee, displayBuffer) != 0) {
             PRINTF("ERR_SILENT_MODE_CHECK_FAILED, fees check failed\n");
+            PRINTF("Expected %s\n", strings.common.maxFee);
+            PRINTF("Received %s\n", displayBuffer);
             THROW(ERR_SILENT_MODE_CHECK_FAILED);
         }
     } else {


### PR DESCRIPTION
## Description

Return to Exchange when failing to sign in swap mode instead of wiping context
Align with other coins

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
