### PR TITLE
Further reduce stack usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,6 +266,9 @@ else
     APP_SOURCE_PATH += src_bagl
 endif
 
+# Allow usage of function from lib_standard_app/crypto_helpers.c
+APP_SOURCE_FILES += ${BOLOS_SDK}/lib_standard_app/crypto_helpers.c
+
 ### initialize plugin SDK submodule if needed, rebuild it, and warn if a difference is noticed
 ifeq ($(CHAIN),ethereum)
     ifneq ($(shell git submodule status | grep '^[-+]'),)

--- a/src_features/signTx/ui_common_signTx.c
+++ b/src_features/signTx/ui_common_signTx.c
@@ -1,3 +1,4 @@
+#include "lib_standard_app/crypto_helpers.h"
 #include "os_io_seproxyhal.h"
 #include "shared_context.h"
 #include "utils.h"
@@ -5,30 +6,21 @@
 #include "handle_swap_sign_transaction.h"
 
 unsigned int io_seproxyhal_touch_tx_ok(__attribute__((unused)) const bagl_element_t *e) {
-    uint8_t privateKeyData[INT256_LENGTH];
-    uint8_t signature[100];
-    cx_ecfp_private_key_t privateKey;
-    uint32_t tx = 0;
+    uint32_t info = 0;
     int err;
-    io_seproxyhal_io_heartbeat();
-    os_perso_derive_node_bip32(CX_CURVE_256K1,
-                               tmpCtx.transactionContext.bip32.path,
-                               tmpCtx.transactionContext.bip32.length,
-                               privateKeyData,
-                               NULL);
-    cx_ecfp_init_private_key(CX_CURVE_256K1, privateKeyData, 32, &privateKey);
-    explicit_bzero(privateKeyData, sizeof(privateKeyData));
-    unsigned int info = 0;
-    io_seproxyhal_io_heartbeat();
-    cx_ecdsa_sign(&privateKey,
-                  CX_RND_RFC6979 | CX_LAST,
-                  CX_SHA256,
-                  tmpCtx.transactionContext.hash,
-                  sizeof(tmpCtx.transactionContext.hash),
-                  signature,
-                  sizeof(signature),
-                  &info);
-    explicit_bzero(&privateKey, sizeof(privateKey));
+    if (bip32_derive_ecdsa_sign_rs_hash_256(CX_CURVE_256K1,
+                                            tmpCtx.transactionContext.bip32.path,
+                                            tmpCtx.transactionContext.bip32.length,
+                                            CX_RND_RFC6979 | CX_LAST,
+                                            CX_SHA256,
+                                            tmpCtx.transactionContext.hash,
+                                            sizeof(tmpCtx.transactionContext.hash),
+                                            G_io_apdu_buffer + 1,
+                                            G_io_apdu_buffer + 1 + 32,
+                                            &info) != CX_OK) {
+        THROW(0x6F00);
+    }
+
     if (txContext.txType == EIP1559 || txContext.txType == EIP2930) {
         if (info & CX_ECCINFO_PARITY_ODD) {
             G_io_apdu_buffer[0] = 1;
@@ -57,13 +49,13 @@ unsigned int io_seproxyhal_touch_tx_ok(__attribute__((unused)) const bagl_elemen
             G_io_apdu_buffer[0] += 2;
         }
     }
-    format_signature_out(signature);
-    tx = 65;
-    G_io_apdu_buffer[tx++] = 0x90;
-    G_io_apdu_buffer[tx++] = 0x00;
+
+    // Write status code at parity_byte + r + s
+    G_io_apdu_buffer[1 + 64] = 0x90;
+    G_io_apdu_buffer[1 + 64 + 1] = 0x00;
 
     // Send back the response, do not restart the event loop
-    err = io_exchange(CHANNEL_APDU | IO_RETURN_AFTER_TX, tx);
+    err = io_exchange(CHANNEL_APDU | IO_RETURN_AFTER_TX, 1 + 64 + 2);
     if (G_called_from_swap) {
         PRINTF("G_called_from_swap\n");
 


### PR DESCRIPTION
## Description

During signature, move parsing and swap fields checking away from main flow
Use standard app crypto helper to simplify io_seproxyhal_touch_tx_ok

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
