### PR TITLE
Fix comparison for token ticker length being off by one

### DIFF
--- a/src_features/provideErc20TokenInformation/cmd_provideTokenInfo.c
+++ b/src_features/provideErc20TokenInformation/cmd_provideTokenInfo.c
@@ -127,7 +127,7 @@ void handleProvideErc20TokenInformation(uint8_t p1,
     }
     tickerLength = workBuffer[offset++];
     dataLength--;
-    if ((tickerLength + 1) >= sizeof(token->ticker)) {
+    if ((tickerLength + 1) > sizeof(token->ticker)) {
         THROW(0x6A80);
     }
     if (dataLength < tickerLength + 20 + 4 + 4) {


### PR DESCRIPTION
## Description

Would refuse a PROVIDE_ERC20_TOKEN_INFORMATION for `crvEURTUSD` even though it is 10 characters long.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)