### PR TITLE
EVM swap

### DIFF
--- a/src/eth_plugin_handler.c
+++ b/src/eth_plugin_handler.c
@@ -67,7 +67,9 @@ void eth_plugin_prepare_query_contract_UI(ethQueryContractUI_t *queryContractUI,
 
     queryContractUI->screenIndex = screenIndex;
     chain_id = get_tx_chain_id();
-    strlcpy(queryContractUI->network_ticker, get_displayable_ticker(&chain_id), MAX_TICKER_LEN);
+    strlcpy(queryContractUI->network_ticker,
+            get_displayable_ticker(&chain_id, chainConfig),
+            sizeof(queryContractUI->network_ticker));
     queryContractUI->title = title;
     queryContractUI->titleLength = titleLength;
     queryContractUI->msg = msg;

--- a/src/handle_swap_sign_transaction.c
+++ b/src/handle_swap_sign_transaction.c
@@ -5,6 +5,7 @@
 #include "handle_swap_sign_transaction.h"
 #include "shared_context.h"
 #include "common_utils.h"
+#include "network.h"
 #ifdef HAVE_NBGL
 #include "nbgl_use_case.h"
 #endif  // HAVE_NBGL
@@ -27,12 +28,15 @@ bool copy_transaction_parameters(create_transaction_parameters_t* sign_transacti
         return false;
     }
 
-    uint8_t decimals;
     char ticker[MAX_TICKER_LEN];
+    uint8_t decimals;
+    uint64_t chain_id = 0;
+
     if (!parse_swap_config(sign_transaction_params->coin_configuration,
                            sign_transaction_params->coin_configuration_length,
                            ticker,
-                           &decimals)) {
+                           &decimals,
+                           &chain_id)) {
         PRINTF("Error while parsing config\n");
         return false;
     }
@@ -46,7 +50,7 @@ bool copy_transaction_parameters(create_transaction_parameters_t* sign_transacti
     }
 
     // If the amount is a fee, its value is nominated in ETH even if we're doing an ERC20 swap
-    strlcpy(ticker, config->coinName, MAX_TICKER_LEN);
+    strlcpy(ticker, get_displayable_ticker(&chain_id, config), sizeof(ticker));
     decimals = WEI_TO_ETHER;
     if (!amountToString(sign_transaction_params->fee_amount,
                         sign_transaction_params->fee_amount_length,

--- a/src/network.c
+++ b/src/network.c
@@ -136,11 +136,11 @@ uint64_t get_tx_chain_id(void) {
     return chain_id;
 }
 
-const char *get_displayable_ticker(const uint64_t *chain_id) {
+const char *get_displayable_ticker(const uint64_t *chain_id, const chain_config_t *chain_cfg) {
     const char *ticker = get_network_ticker_from_chain_id(chain_id);
 
     if (ticker == NULL) {
-        ticker = chainConfig->coinName;
+        ticker = chain_cfg->coinName;
     }
     return ticker;
 }

--- a/src/network.h
+++ b/src/network.h
@@ -2,6 +2,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "chainConfig.h"
 
 #define UNSUPPORTED_CHAIN_ID_MSG(id)                                              \
     do {                                                                          \
@@ -16,4 +17,4 @@ bool app_compatible_with_chain_id(const uint64_t *chain_id);
 
 uint64_t get_tx_chain_id(void);
 
-const char *get_displayable_ticker(const uint64_t *chain_id);
+const char *get_displayable_ticker(const uint64_t *chain_id, const chain_config_t *chain_cfg);

--- a/src/swap_utils.h
+++ b/src/swap_utils.h
@@ -19,4 +19,8 @@
 
 #include <stdint.h>
 
-bool parse_swap_config(const uint8_t* config, uint8_t config_len, char* ticker, uint8_t* decimals);
+bool parse_swap_config(const uint8_t* config,
+                       uint8_t config_len,
+                       char* ticker,
+                       uint8_t* decimals,
+                       uint64_t* chain_id);

--- a/src_features/signTx/logic_signTx.c
+++ b/src_features/signTx/logic_signTx.c
@@ -200,7 +200,7 @@ static void address_to_string(uint8_t *in,
 
 static void raw_fee_to_string(uint256_t *rawFee, char *displayBuffer, uint32_t displayBufferSize) {
     uint64_t chain_id = get_tx_chain_id();
-    const char *feeTicker = get_displayable_ticker(&chain_id);
+    const char *feeTicker = get_displayable_ticker(&chain_id, chainConfig);
     uint8_t tickerOffset = 0;
     uint32_t i;
 
@@ -323,7 +323,7 @@ __attribute__((noinline)) static void finalize_parsing_helper(bool direct, bool 
     char displayBuffer[50];
     uint8_t decimals = WEI_TO_ETHER;
     uint64_t chain_id = get_tx_chain_id();
-    const char *ticker = get_displayable_ticker(&chain_id);
+    const char *ticker = get_displayable_ticker(&chain_id, chainConfig);
     ethPluginFinalize_t pluginFinalize;
 
     *use_standard_UI = true;


### PR DESCRIPTION
## Description

Swap is now possible for EVM chains with the Ethereum app directly.
The app was missing one information lost from not going through the clone first : the chain ID.
Support was added for parsing the chain ID from the swap coin sub config (if present, so not a breaking change with current CAL).

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)