### PR TITLE
Bump plugin context size to 10x32

### DIFF
--- a/src/shared_context.h
+++ b/src/shared_context.h
@@ -60,7 +60,9 @@ typedef struct tokenContext_t {
         };
         // This needs to be strictly 4 bytes aligned since pointers to it will be casted as
         // plugin context struct pointers (structs that contain up to 4 bytes wide elements)
-        uint8_t pluginContext[5 * INT256_LENGTH] __attribute__((aligned(4)));
+        // uint8_t pluginContext[5 * INT256_LENGTH] __attribute__((aligned(4)));
+        // TODO: use PLUGIN_CONTEXT_SIZE after eth is released with the updated plugin sdk
+        uint8_t pluginContext[10 * INT256_LENGTH] __attribute__((aligned(4)));
     };
 
     uint8_t pluginStatus;


### PR DESCRIPTION
## Description

Bump plugin context size to 10x32

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

