### PR TITLE
Remove filters counter check at the end of EIP712 flow

### DIFF
--- a/src_features/signMessageEIP712/commands_712.c
+++ b/src_features/signMessageEIP712/commands_712.c
@@ -196,10 +196,6 @@ bool handle_eip712_sign(const uint8_t *const apdu_buf) {
                        sizeof(tmpCtx.messageSigningContext712.messageHash)) ||
              (path_get_field() != NULL)) {
         apdu_response_code = APDU_RESPONSE_CONDITION_NOT_SATISFIED;
-    } else if ((ui_712_get_filtering_mode() == EIP712_FILTERING_FULL) &&
-               (ui_712_remaining_filters() != 0)) {
-        PRINTF("%d EIP712 filters are missing\n", ui_712_remaining_filters());
-        apdu_response_code = APDU_RESPONSE_REF_DATA_NOT_FOUND;
     } else if (parseBip32(&apdu_buf[OFFSET_CDATA], &length, &tmpCtx.messageSigningContext.bip32) !=
                NULL) {
         if (!N_storage.verbose_eip712 && (ui_712_get_filtering_mode() == EIP712_FILTERING_BASIC)) {


### PR DESCRIPTION
## Description

Has always been kind of broken, and can actually cause issues if a filter has been defined for a field inside of an array which turns out to be empty, the app will complain at the very end of the flow that some filters are missing.
This could be improved in the future.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)