### PR TITLE
Increase max assets to 5 + LNS ram optimization

### DIFF
--- a/src/shared_context.h
+++ b/src/shared_context.h
@@ -22,7 +22,7 @@
 
 #define N_storage (*(volatile internalStorage_t *) PIC(&N_storage_real))
 
-#define MAX_ASSETS MAX_ITEMS  // TODO: Temporary, remove once plugin SDK is updated
+#define MAX_ASSETS 5
 
 typedef struct bip32_path_t {
     uint8_t length;


### PR DESCRIPTION
## Description

* Now can store 5 asset information at once (previously 2)
* Update to the [latest plugin SDK](https://github.com/LedgerHQ/ethereum-plugin-sdk/pull/14)

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)