### PR TITLE
EIP-712 filters counter fix + reactivation

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -11,7 +11,7 @@
 #include <stdint.h>
 #include "mem.h"
 
-#define SIZE_MEM_BUFFER 8192
+#define SIZE_MEM_BUFFER 10240
 
 static uint8_t mem_buffer[SIZE_MEM_BUFFER];
 static size_t mem_idx;

--- a/src_bagl/ui_flow_signMessage712.c
+++ b/src_bagl/ui_flow_signMessage712.c
@@ -12,10 +12,9 @@ static void dummy_cb(void) {
             if (ui_pos == UI_712_POS_REVIEW) {
                 ux_flow_next();
                 ui_pos = UI_712_POS_END;
-            } else  // UI_712_POS_END
-            {
-                ux_flow_prev();
-                ui_pos = UI_712_POS_REVIEW;
+            } else {
+                // Keep user at the end of the flow
+                ux_flow_next();
             }
             break;
         case EIP712_FIELD_INCOMING:

--- a/src_features/signMessageEIP712/commands_712.c
+++ b/src_features/signMessageEIP712/commands_712.c
@@ -229,6 +229,10 @@ bool handle_eip712_sign(const uint8_t *const apdu_buf) {
                        sizeof(tmpCtx.messageSigningContext712.messageHash)) ||
              (path_get_field() != NULL)) {
         apdu_response_code = APDU_RESPONSE_CONDITION_NOT_SATISFIED;
+    } else if ((ui_712_get_filtering_mode() == EIP712_FILTERING_FULL) &&
+               (ui_712_remaining_filters() != 0)) {
+        PRINTF("%d EIP712 filters are missing\n", ui_712_remaining_filters());
+        apdu_response_code = APDU_RESPONSE_REF_DATA_NOT_FOUND;
     } else if (parseBip32(&apdu_buf[OFFSET_CDATA], &length, &tmpCtx.messageSigningContext.bip32) !=
                NULL) {
         if (!N_storage.verbose_eip712 && (ui_712_get_filtering_mode() == EIP712_FILTERING_BASIC)) {

--- a/src_features/signMessageEIP712/commands_712.c
+++ b/src_features/signMessageEIP712/commands_712.c
@@ -195,6 +195,14 @@ bool handle_eip712_filtering(const uint8_t *const apdu_buf) {
             apdu_response_code = APDU_RESPONSE_INVALID_P1_P2;
             ret = false;
     }
+    if ((apdu_buf[OFFSET_P2] > P2_FILT_MESSAGE_INFO) && ret) {
+        if (ui_712_push_new_filter_path()) {
+            if (!ui_712_filters_counter_incr()) {
+                ret = false;
+                apdu_response_code = APDU_RESPONSE_INVALID_DATA;
+            }
+        }
+    }
     if (reply_apdu) {
         handle_eip712_return_code(ret);
     }

--- a/src_features/signMessageEIP712/filtering.c
+++ b/src_features/signMessageEIP712/filtering.c
@@ -11,6 +11,7 @@
 #include "typed_data.h"
 #include "path.h"
 #include "ui_logic.h"
+#include "filtering.h"
 
 #define FILT_MAGIC_MESSAGE_INFO      183
 #define FILT_MAGIC_AMOUNT_JOIN_TOKEN 11
@@ -188,6 +189,10 @@ bool filtering_message_info(const uint8_t *payload, uint8_t length) {
         return false;
     }
     filters_count = payload[offset++];
+    if (filters_count > MAX_FILTERS) {
+        PRINTF("%u filters planned but can only store up to %u.\n", filters_count, MAX_FILTERS);
+        return false;
+    }
     if ((offset + sizeof(sig_len)) > length) {
         return false;
     }

--- a/src_features/signMessageEIP712/filtering.h
+++ b/src_features/signMessageEIP712/filtering.h
@@ -6,6 +6,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#define MAX_FILTERS 50
+
 bool filtering_message_info(const uint8_t *payload, uint8_t length);
 bool filtering_date_time(const uint8_t *payload, uint8_t length);
 bool filtering_amount_join_token(const uint8_t *payload, uint8_t length);

--- a/src_features/signMessageEIP712/path.h
+++ b/src_features/signMessageEIP712/path.h
@@ -37,6 +37,7 @@ const void *path_get_root(void);
 const void *path_get_nth_field(uint8_t n);
 const void *path_get_nth_field_to_last(uint8_t n);
 uint8_t path_get_depth_count(void);
+uint32_t get_path_crc(void);
 
 #endif  // HAVE_EIP712_FULL_SUPPORT
 

--- a/src_features/signMessageEIP712/ui_logic.h
+++ b/src_features/signMessageEIP712/ui_logic.h
@@ -38,11 +38,12 @@ e_eip712_filtering_mode ui_712_get_filtering_mode(void);
 void ui_712_set_filters_count(uint8_t count);
 uint8_t ui_712_remaining_filters(void);
 void ui_712_queue_struct_to_review(void);
-void ui_712_notify_filter_change(void);
+bool ui_712_filters_counter_incr(void);
 void ui_712_token_join_prepare_addr_check(uint8_t index);
 void ui_712_token_join_prepare_amount(uint8_t index, const char *name, uint8_t name_length);
 void amount_join_set_token_received(void);
 bool ui_712_show_raw_key(const void *field_ptr);
+bool ui_712_push_new_filter_path(void);
 #ifdef SCREEN_SIZE_WALLET
 char *get_ui_pairs_buffer(size_t *size);
 #endif


### PR DESCRIPTION
## Description

Re-activate & fix the EIP-712 filters counter which was disabled in #582, now properly counts unique filters.
The proper handling of filtered path within empty arrays will come later since it also requires a ledgerjs modification.

Uses yet again a bit more RAM (200 bytes) so increased the RAM buffer to make up for it.
Now on Nanos, does not let the user go back to the review page once he has reached the approve/reject.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)