### PR TITLE
Fix EIP-712 end of empty arrays traversal

### DIFF
--- a/src_features/signMessageEIP712/path.h
+++ b/src_features/signMessageEIP712/path.h
@@ -28,7 +28,7 @@ typedef struct {
 
 bool path_set_root(const char *const struct_name, uint8_t length);
 const void *path_get_field(void);
-bool path_advance(bool array_check);
+bool path_advance(bool do_typehash);
 bool path_init(void);
 void path_deinit(void);
 bool path_new_array_depth(const uint8_t *const data, uint8_t length);


### PR DESCRIPTION
## Description

If the app was skipping an empty array that was followed by a non-empty array of structs, the app would not stop at the struct array field but instead at its first non-array child, so its typehash was not computed and the resulting message hash was wrong.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)