### PR TITLE
Improved EIP-712 error handling

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -258,12 +258,14 @@ void app_main(void) {
                     PRINTF("=> BAD LENGTH: %d\n", rx);
                     sw = APDU_RESPONSE_WRONG_DATA_LENGTH;
                 } else {
-                    PRINTF("=> CLA=%02X | INS=%02X | P1=%02X | P2=%02X | Lc=%02X\n",
+                    PRINTF("=> CLA=%02x, INS=%02x, P1=%02x, P2=%02x, LC=%02x, CDATA=%.*h\n",
                            cmd.cla,
                            cmd.ins,
                            cmd.p1,
                            cmd.p2,
-                           cmd.lc);
+                           cmd.lc,
+                           cmd.lc,
+                           cmd.data);
 
                     tx = 0;
                     flags = 0;

--- a/src_features/signMessageEIP712/path.c
+++ b/src_features/signMessageEIP712/path.c
@@ -370,7 +370,9 @@ bool path_set_root(const char *const struct_name, uint8_t name_length) {
         return false;
     }
 
-    path_struct->root_struct = get_structn(struct_name, name_length);
+    if ((path_struct->root_struct = get_structn(struct_name, name_length)) == NULL) {
+        return false;
+    }
 
     if (path_struct->root_struct == NULL) {
         PRINTF("Struct name not found (");


### PR DESCRIPTION
## Description

Non-sensical type definitions could make the EIP-712 `type_hash` function crash.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)