### PR TITLE
EIP-712 pairs packing overflow on Stax

### DIFF
--- a/src_nbgl/ui_sign_712.c
+++ b/src_nbgl/ui_sign_712.c
@@ -9,7 +9,7 @@
 #include "ui_message_signing.h"
 #include "ledger_assert.h"
 
-static nbgl_contentTagValue_t pairs[6];
+static nbgl_contentTagValue_t pairs[7];
 static nbgl_contentTagValueList_t pairs_list;
 static uint8_t pair_idx;
 static size_t buf_idx;
@@ -56,7 +56,7 @@ static void message_update(bool confirm) {
         buf_idx += buf_off;
         pair_idx += 1;
         pairs_list.nbPairs = nbgl_useCaseGetNbTagValuesInPage(pair_idx, &pairs_list, 0, &flag);
-        if (pairs_list.nbPairs < pair_idx) {
+        if ((pair_idx == ARRAYLEN(pairs)) || (pairs_list.nbPairs < pair_idx)) {
             nbgl_useCaseReviewStreamingContinue(&pairs_list, message_progress);
         } else {
             message_progress(true);


### PR DESCRIPTION
## Description

Stax screen being taller than other devices, it can fit more pairs in one page, and the list of pairs was too small so it would try to fit more pairs than can be stored at once and crash.
Increased the size by one and added an overflow check, so if it can ever fit more than planned today, it won't try to.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)