### PR TITLE
Fix EIP-712 discarded filters

### DIFF
--- a/src_features/signMessageEIP712/commands_712.c
+++ b/src_features/signMessageEIP712/commands_712.c
@@ -184,6 +184,7 @@ uint16_t handle_eip712_filtering(uint8_t p1,
                                  uint32_t *flags) {
     bool ret = true;
     bool reply_apdu = true;
+    uint32_t path_crc = 0;
 
     if (eip712_context == NULL) {
         apdu_reply(false);
@@ -211,20 +212,20 @@ uint16_t handle_eip712_filtering(uint8_t p1,
             break;
 #ifdef HAVE_TRUSTED_NAME
         case P2_FILT_CONTRACT_NAME:
-            ret = filtering_trusted_name(cdata, length, p1 == 1);
+            ret = filtering_trusted_name(cdata, length, p1 == 1, &path_crc);
             break;
 #endif
         case P2_FILT_DATE_TIME:
-            ret = filtering_date_time(cdata, length, p1 == 1);
+            ret = filtering_date_time(cdata, length, p1 == 1, &path_crc);
             break;
         case P2_FILT_AMOUNT_JOIN_TOKEN:
-            ret = filtering_amount_join_token(cdata, length, p1 == 1);
+            ret = filtering_amount_join_token(cdata, length, p1 == 1, &path_crc);
             break;
         case P2_FILT_AMOUNT_JOIN_VALUE:
-            ret = filtering_amount_join_value(cdata, length, p1 == 1);
+            ret = filtering_amount_join_value(cdata, length, p1 == 1, &path_crc);
             break;
         case P2_FILT_RAW_FIELD:
-            ret = filtering_raw_field(cdata, length, p1 == 1);
+            ret = filtering_raw_field(cdata, length, p1 == 1, &path_crc);
             break;
         default:
             PRINTF("Unknown P2 0x%x\n", p2);
@@ -232,7 +233,7 @@ uint16_t handle_eip712_filtering(uint8_t p1,
             ret = false;
     }
     if ((p2 > P2_FILT_MESSAGE_INFO) && ret) {
-        if (ui_712_push_new_filter_path()) {
+        if (ui_712_push_new_filter_path(path_crc)) {
             if (!ui_712_filters_counter_incr()) {
                 ret = false;
                 apdu_response_code = APDU_RESPONSE_INVALID_DATA;

--- a/src_features/signMessageEIP712/filtering.h
+++ b/src_features/signMessageEIP712/filtering.h
@@ -9,11 +9,26 @@
 #define MAX_FILTERS 50
 
 bool filtering_message_info(const uint8_t *payload, uint8_t length);
-bool filtering_trusted_name(const uint8_t *payload, uint8_t length, bool discarded);
-bool filtering_date_time(const uint8_t *payload, uint8_t length, bool discarded);
-bool filtering_amount_join_token(const uint8_t *payload, uint8_t length, bool discarded);
-bool filtering_amount_join_value(const uint8_t *payload, uint8_t length, bool discarded);
-bool filtering_raw_field(const uint8_t *payload, uint8_t length, bool discarded);
+bool filtering_trusted_name(const uint8_t *payload,
+                            uint8_t length,
+                            bool discarded,
+                            uint32_t *path_crc);
+bool filtering_date_time(const uint8_t *payload,
+                         uint8_t length,
+                         bool discarded,
+                         uint32_t *path_crc);
+bool filtering_amount_join_token(const uint8_t *payload,
+                                 uint8_t length,
+                                 bool discarded,
+                                 uint32_t *path_crc);
+bool filtering_amount_join_value(const uint8_t *payload,
+                                 uint8_t length,
+                                 bool discarded,
+                                 uint32_t *path_crc);
+bool filtering_raw_field(const uint8_t *payload,
+                         uint8_t length,
+                         bool discarded,
+                         uint32_t *path_crc);
 bool filtering_discarded_path(const uint8_t *payload, uint8_t length);
 
 #endif  // HAVE_EIP712_FULL_SUPPORT

--- a/src_features/signMessageEIP712/path.c
+++ b/src_features/signMessageEIP712/path.c
@@ -708,7 +708,6 @@ bool path_exists_in_backup(const char *path, size_t length) {
     size_t offset = 0;
     size_t i;
     const void *field_ptr;
-    s_path tmp_path;
     const char *typename;
     uint8_t typename_len;
     const void *struct_ptr;
@@ -716,8 +715,7 @@ bool path_exists_in_backup(const char *path, size_t length) {
     const char *key;
     uint8_t key_len;
 
-    memcpy(&tmp_path, path_backup, sizeof(tmp_path));
-    field_ptr = get_nth_field_from(&tmp_path, NULL, tmp_path.depth_count);
+    field_ptr = get_nth_field_from(path_backup, NULL, path_backup->depth_count);
     while (offset < length) {
         if (((offset + 1) > length) || (memcmp(path + offset, ".", 1) != 0)) {
             return false;

--- a/src_features/signMessageEIP712/path.c
+++ b/src_features/signMessageEIP712/path.c
@@ -754,35 +754,6 @@ bool path_exists_in_backup(const char *path, size_t length) {
 }
 
 /**
- * Generate a unique checksum out of the current path
- *
- * Goes over the fields of the \ref path_struct with a few exceptions : we skip the root_type since
- * we already go over root_struct, and in array_depths we only go over path_index since it would
- * otherwise generate a different CRC for different fields which are targeted by the same filtering
- * path.
- *
- * @return CRC-32 checksum
- */
-uint32_t get_path_crc(void) {
-    uint32_t value = 0;
-
-    value = cx_crc32_update(value, &path_struct->root_struct, sizeof(path_struct->root_struct));
-    value = cx_crc32_update(value, &path_struct->depth_count, sizeof(path_struct->depth_count));
-    value = cx_crc32_update(value,
-                            path_struct->depths,
-                            sizeof(path_struct->depths[0]) * path_struct->depth_count);
-    value = cx_crc32_update(value,
-                            &path_struct->array_depth_count,
-                            sizeof(path_struct->array_depth_count));
-    for (int i = 0; i < path_struct->array_depth_count; ++i) {
-        value = cx_crc32_update(value,
-                                &path_struct->array_depths[i].path_index,
-                                sizeof(path_struct->array_depths[i].path_index));
-    }
-    return value;
-}
-
-/**
  * Initialize the path context with its indexes in memory and sets it with a depth of 0.
  *
  * @return whether the memory allocation were successful.

--- a/src_features/signMessageEIP712/path.h
+++ b/src_features/signMessageEIP712/path.h
@@ -40,7 +40,6 @@ bool path_exists_in_backup(const char *path, size_t length);
 const void *path_get_nth_field_to_last(uint8_t n);
 uint8_t path_get_depth_count(void);
 uint8_t path_backup_get_depth_count(void);
-uint32_t get_path_crc(void);
 
 #endif  // HAVE_EIP712_FULL_SUPPORT
 

--- a/src_features/signMessageEIP712/ui_logic.c
+++ b/src_features/signMessageEIP712/ui_logic.c
@@ -882,11 +882,10 @@ bool ui_712_show_raw_key(const void *field_ptr) {
 /**
  * Push a new filter path
  *
+ * @param[in] path_crc CRC of the filter path
  * @return if the path was pushed or not (in case it was already present)
  */
-bool ui_712_push_new_filter_path(void) {
-    uint32_t path_crc = get_path_crc();
-
+bool ui_712_push_new_filter_path(uint32_t path_crc) {
     // check if already present
     for (int i = 0; i < ui_ctx->filters_received; ++i) {
         if (ui_ctx->filters_crc[i] == path_crc) {

--- a/src_features/signMessageEIP712/ui_logic.h
+++ b/src_features/signMessageEIP712/ui_logic.h
@@ -48,7 +48,7 @@ void ui_712_token_join_prepare_addr_check(uint8_t index);
 void ui_712_token_join_prepare_amount(uint8_t index, const char *name, uint8_t name_length);
 void amount_join_set_token_received(void);
 bool ui_712_show_raw_key(const void *field_ptr);
-bool ui_712_push_new_filter_path(void);
+bool ui_712_push_new_filter_path(uint32_t path_crc);
 void ui_712_set_discarded_path(const char *path, uint8_t length);
 const char *ui_712_get_discarded_path(uint8_t *length);
 #ifdef HAVE_TRUSTED_NAME


### PR DESCRIPTION
## Description

For discarded filters, the path CRC was computed on the regular path instead of the backed-up path, so the app could find an already existing CRC in memory when the filter was actually unique.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)