### PR TITLE
[hotfix] ETC with ETH derivation path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Review of EIP-191 messages getting stuck and not responding to APDUs
+- (clone) Ethereum Classic, gave it back the Ethereum derivation path
 
 ## [1.12.0](https://github.com/ledgerhq/app-ethereum/compare/1.11.3...1.12.0) - 2024-09-27
 

--- a/makefile_conf/chain/ethereum_classic.mk
+++ b/makefile_conf/chain/ethereum_classic.mk
@@ -1,5 +1,5 @@
 # Also allows ETC to access the ETH derivation path to recover forked assets
-PATH_APP_LOAD_PARAMS += "44'/61'"
+PATH_APP_LOAD_PARAMS += "44'/61'" "44'/60'"
 TICKER = "ETC"
 CHAIN_ID = 61
 APPNAME = "Ethereum Classic"


### PR DESCRIPTION
## Description

Introduced in #634, Ledger Live uses the clone on both paths (44'/60' & 44'/61').
Might be removed again in the future if Live changes this behaviour.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)