### PR TITLE
Fix amount formatting

### DIFF
--- a/src/shared_context.h
+++ b/src/shared_context.h
@@ -127,7 +127,7 @@ typedef enum {
 typedef struct txStringProperties_s {
     char fromAddress[43];
     char toAddress[43];
-    char fullAmount[79];  // 2^256 is 78 digits long
+    char fullAmount[MAX_TICKER_LEN + 1 + 78 + 1];  // 2^256 is 78 digits long
     char maxFee[50];
     char nonce[8];  // 10M tx per account ought to be enough for everybody
     char network_name[NETWORK_STRING_MAX_SIZE + 1];

--- a/src_plugins/erc20/erc20_plugin.c
+++ b/src_plugins/erc20/erc20_plugin.c
@@ -189,7 +189,7 @@ void erc20_plugin_call(int message, void *parameters) {
                                             context->decimals,
                                             context->ticker,
                                             msg->msg,
-                                            100)) {
+                                            msg->msgLength)) {
                             msg->result = ETH_PLUGIN_RESULT_ERROR;
                             break;
                         }

--- a/src_plugins/eth2/eth2_plugin.c
+++ b/src_plugins/eth2/eth2_plugin.c
@@ -206,7 +206,7 @@ void eth2_plugin_call(int message, void *parameters) {
                                         decimals,
                                         ticker,
                                         msg->msg,
-                                        100)) {
+                                        msg->msgLength)) {
                         msg->result = ETH_PLUGIN_RESULT_ERROR;
                         break;
                     }


### PR DESCRIPTION
## Description

* Fix amount buffer being not big enough to accommodate a ticker if the amount is already the largest possible
* Fix two calls to `amountToString` having a hardcoded (and wrong) output buffer size

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)