### PR TITLE
Fix potential out-of-bounds read by up to 2 bytes during TLV parsing

### DIFF
--- a/src_features/provideDynamicNetwork/network_dynamic.c
+++ b/src_features/provideDynamicNetwork/network_dynamic.c
@@ -493,6 +493,10 @@ static uint16_t parse_tlv(const uint8_t *data, uint8_t length) {
     cx_sha256_init(&sig_ctx.hash_ctx);
     // handle TLV payload
     while (offset != length) {
+        if ((offset + 2) > length) {
+            sw = APDU_RESPONSE_INVALID_DATA;
+            break;
+        }
         tag_start_off = offset;
         field_tag = data[offset++];
         field_len = data[offset++];


### PR DESCRIPTION
## Description

Fix issue identified in security review.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)