### PR TITLE
fix: version compare bug

### DIFF
--- a/src_features/provideTrustedName/cmd_provide_trusted_name.c
+++ b/src_features/provideTrustedName/cmd_provide_trusted_name.c
@@ -222,8 +222,11 @@ static bool handle_not_valid_after(const s_tlv_data *data,
     if (data->length != ARRAYLEN(app_version)) {
         return false;
     }
-    do {
-        if (data->value[i] < app_version[i]) {
+
+    for (; i < (int) ARRAYLEN(app_version); ++i) {
+        if (data->value[i] > app_version[i]) {
+            break;
+        } else if (data->value[i] < app_version[i]) {
             PRINTF("Expired trusted name : %u.%u.%u < %u.%u.%u\n",
                    data->value[0],
                    data->value[1],
@@ -233,8 +236,7 @@ static bool handle_not_valid_after(const s_tlv_data *data,
                    app_version[2]);
             return false;
         }
-        i += 1;
-    } while ((i < (int) ARRAYLEN(app_version)) && (data->value[i] == app_version[i]));
+    }
     return true;
 }
 


### PR DESCRIPTION
## Description

In the version comparison, the index i has already been incremented by 1.
This actually compares the next sub-version, but we expect to enter the next loop only if the current sub-version is the same.

## Changes include


## Breaking changes


## Additional comments

## Reproduce

Enable the CAL_TEST_KEY and TRUSTED_NAME_TEST_KEY. (You can simply add two lines in the Makefile. CAL_TEST_KEY=1 TRUSTED_NAME_TEST_KEY=1)
In UT test_trusted_name_v2_expired，change the arg `not_valid_after ` to (1,1,2)，it  will fail to run.

