### PR TITLE
Fix trusted name expiration check

### DIFF
--- a/src_features/provideTrustedName/cmd_provide_trusted_name.c
+++ b/src_features/provideTrustedName/cmd_provide_trusted_name.c
@@ -215,14 +215,13 @@ static bool handle_not_valid_after(const s_tlv_data *data,
                                    s_trusted_name_info *trusted_name_info,
                                    s_sig_ctx *sig_ctx) {
     const uint8_t app_version[] = {MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION};
-    int i = 0;
 
     (void) trusted_name_info;
     (void) sig_ctx;
     if (data->length != ARRAYLEN(app_version)) {
         return false;
     }
-    do {
+    for (int i = 0; i < (int) ARRAYLEN(app_version); ++i) {
         if (data->value[i] < app_version[i]) {
             PRINTF("Expired trusted name : %u.%u.%u < %u.%u.%u\n",
                    data->value[0],
@@ -233,8 +232,7 @@ static bool handle_not_valid_after(const s_tlv_data *data,
                    app_version[2]);
             return false;
         }
-        i += 1;
-    } while ((i < (int) ARRAYLEN(app_version)) && (data->value[i] == app_version[i]));
+    }
     return true;
 }
 

--- a/tests/ragger/conftest.py
+++ b/tests/ragger/conftest.py
@@ -3,8 +3,12 @@ from pathlib import Path
 from os import path
 import warnings
 import glob
+import re
+
+import pytest
 
 from ragger.conftest import configuration
+
 
 #######################
 # CONFIGURATION START #
@@ -13,6 +17,7 @@ from ragger.conftest import configuration
 # You can configure optional parameters by overriding the value of
 # ragger.configuration.OPTIONAL_CONFIGURATION
 # Please refer to ragger/conftest/configuration.py for their descriptions and accepted values
+
 
 def pytest_addoption(parser):
     parser.addoption("--with_lib_mode", action="store_true", help="Run the test with Library Mode")
@@ -40,6 +45,15 @@ else:
     # ===========================================================================
 
     collect_ignore += [f for f in testFiles if "test_clone" in f]
+
+
+@pytest.fixture(name="app_version")
+def app_version_fixture(request) -> tuple[int, int, int]:
+    with open(Path(__file__).parent.parent.parent / "Makefile") as f:
+        parsed = dict()
+        for m in re.findall(r"^APPVERSION_(\w)\s*=\s*(\d*)$", f.read(), re.MULTILINE):
+            parsed[m[0]] = int(m[1])
+    return (parsed["M"], parsed["N"], parsed["P"])
 
 
 #####################

--- a/tests/ragger/test_trusted_name.py
+++ b/tests/ragger/test_trusted_name.py
@@ -284,9 +284,21 @@ def test_trusted_name_v2_missing_challenge(firmware: Firmware, backend: BackendI
     assert e.value.status == StatusWord.INVALID_DATA
 
 
-def test_trusted_name_v2_expired(firmware: Firmware, backend: BackendInterface):
+def test_trusted_name_v2_expired(firmware: Firmware, backend: BackendInterface, app_version: tuple[int, int, int]):
     app_client = EthAppClient(backend)
     challenge = common(firmware, app_client)
+
+    # convert to list and reverse
+    app_version = list(app_version)
+    app_version.reverse()
+    # simulate a previous version number by decrementing the first non-zero value
+    for idx, v in enumerate(app_version):
+        if v > 0:
+            app_version[idx] -= 1
+            break
+    # reverse and convert back
+    app_version.reverse()
+    app_version = tuple(app_version)
 
     with pytest.raises(ExceptionRAPDU) as e:
         app_client.provide_trusted_name_v2(ADDR,
@@ -295,5 +307,5 @@ def test_trusted_name_v2_expired(firmware: Firmware, backend: BackendInterface):
                                            TrustedNameSource.ENS,
                                            CHAIN_ID,
                                            challenge=challenge,
-                                           not_valid_after=(0, 1, 2))
+                                           not_valid_after=app_version)
     assert e.value.status == StatusWord.INVALID_DATA


### PR DESCRIPTION
## Description

The version comparison loop was, for some reason, looping only as long as each element of the version numbers were the same.
Removed that condition and switched to a simpler `for () {}` loop.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [x] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)