### PR TITLE
eth,plugin: improve plugin finalize error checks

### DIFF
--- a/src_features/signTx/logic_signTx.c
+++ b/src_features/signTx/logic_signTx.c
@@ -435,7 +435,8 @@ __attribute__((noinline)) static uint16_t finalize_parsing_helper(const txContex
 
         pluginFinalize.address = msg_sender;
 
-        if (!eth_plugin_call(ETH_PLUGIN_FINALIZE, (void *) &pluginFinalize)) {
+        if (eth_plugin_call(ETH_PLUGIN_FINALIZE, (void *) &pluginFinalize) <
+            ETH_PLUGIN_RESULT_SUCCESSFUL) {
             PRINTF("Plugin finalize call failed\n");
             report_finalize_error();
             return APDU_NO_RESPONSE;


### PR DESCRIPTION
Return invalid data status unless return is okay.

## Description

Handle finalize error if return code is an error result code, not only zero.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

