### PR TITLE
Fix for fuzzing false positive with unitialized variables

### DIFF
--- a/tests/fuzzing/CMakeLists.txt
+++ b/tests/fuzzing/CMakeLists.txt
@@ -155,6 +155,7 @@ set(DEFINES
     HAVE_ENUM_VALUE
     HAVE_NFT_SUPPORT
     HAVE_DYNAMIC_NETWORKS
+    explicit_bzero=bzero # Fix for https://github.com/google/sanitizers/issues/1507
 )
 
 add_compile_definitions(${DEFINES})


### PR DESCRIPTION
## Description

`explicit_bzero` isn't counted as initializing a variable for the fuzzer.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [x] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)