### PR TITLE
Fix compatibility with Python 3.11

### DIFF
--- a/client/src/ledger_app_clients/ethereum/eip712/struct.py
+++ b/client/src/ledger_app_clients/ethereum/eip712/struct.py
@@ -2,7 +2,7 @@ from enum import IntEnum, auto
 
 
 class EIP712FieldType(IntEnum):
-    CUSTOM = 0,
+    CUSTOM = 0
     INT = auto()
     UINT = auto()
     ADDRESS = auto()

--- a/tests/ragger/test_eip712.py
+++ b/tests/ragger/test_eip712.py
@@ -721,9 +721,9 @@ def test_eip712_advanced_trusted_name(firmware: Firmware,
                                       golden_run: bool):
     global snapshots_dirname
 
-    test_name += "_%s_with" % (str(trusted_name[0]).split(".")[-1].lower())
+    test_name += "_%s_with" % (trusted_name[0].name.lower())
     for t in filt_tn_types:
-        test_name += "_%s" % (str(t).split(".")[-1].lower())
+        test_name += "_%s" % (t.name.lower())
     snapshots_dirname = test_name
 
     app_client = EthAppClient(backend)


### PR DESCRIPTION
## Description

* One syntax error that Python 3.10 was permissive to
* One actual change of Python 3.11 around the handling of `Enum` types

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)