### PR TITLE
Improve network info support

### DIFF
--- a/doc/ethapp.adoc
+++ b/doc/ethapp.adoc
@@ -1230,25 +1230,38 @@ _Command_
 
 [width="80%"]
 |==============================================================
-| *CLA*     | *INS*    | *P1*             | *P2*                       | *LC*     | *Le*
-.3+| E0  .3+| 30       | 00               | 00 : Network configuration | variable | variable
-                       | 01 : First chunk
+| *CLA*     | *INS*    | *P1*             | *P2*                       | *LC*
+.2+| E0     .2+| 30    | 01 : first chunk
 
-                         00: Next chunks  | 01 : Network Icon          | variable | variable
-                       | 00               | 02 : Get Info              |          |
+                         00 : following chunk
+                                          | 00 : Network configuration
+
+                                            01 : Network icon          | variable
+                       | 00               | 02 : Get info              | 0
 |==============================================================
 
 _Input data_
 
-##### If P1 == Network configuration
+##### If P2 == Network configuration
+
+###### If P1 == first chunk
 
 [width="80%"]
 |==========================================
 | *Description*         | *Length (byte)*
-| TLV payload data      | variable
+| Payload length        | 2
+| TLV payload           | variable
 |==========================================
 
-##### If P1 == Network Icon
+###### If P1 == following chunk
+
+[width="80%"]
+|==========================================
+| *Description*         | *Length (byte)*
+| TLV payload           | variable
+|==========================================
+
+##### If P2 == Network Icon
 
 [width="80%"]
 |==========================================
@@ -1268,7 +1281,7 @@ _Input data_
 
 _Output data_
 
-##### If P1 == Get Info
+##### If P2 == Get Info
 
 [width="80%"]
 |==========================================

--- a/src/network.c
+++ b/src/network.c
@@ -126,7 +126,9 @@ static const network_info_t *get_network_from_chain_id(const uint64_t *chain_id)
         // Look if the network is available
         for (size_t i = 0; i < MAX_DYNAMIC_NETWORKS; i++) {
             if (DYNAMIC_NETWORK_INFO[i].chain_id == *chain_id) {
-                PRINTF("[NETWORK] - Found dynamic %s\n", DYNAMIC_NETWORK_INFO[i].name);
+                PRINTF("[NETWORK] - Found dynamic \"%s\" in slot %u\n",
+                       DYNAMIC_NETWORK_INFO[i].name,
+                       i);
                 return (const network_info_t *) &DYNAMIC_NETWORK_INFO[i];
             }
         }

--- a/src_features/provide_network_info/cmd_network_info.c
+++ b/src_features/provide_network_info/cmd_network_info.c
@@ -258,7 +258,6 @@ static bool handle_tlv_payload(const uint8_t *payload, uint16_t size, bool to_fr
     parsing_ret = tlv_parse(payload, size, (f_tlv_data_handler) &handle_network_info_struct, &ctx);
     if (to_free) mem_dealloc(sizeof(size));
     if (!parsing_ret || !verify_network_info_struct(&ctx)) {
-        explicit_bzero(&DYNAMIC_NETWORK_INFO[g_current_network_slot], sizeof(network_info_t));
         return false;
     }
     print_network_info();

--- a/src_features/provide_network_info/cmd_network_info.c
+++ b/src_features/provide_network_info/cmd_network_info.c
@@ -212,7 +212,7 @@ static void print_network_info(void) {
     u64_to_string(DYNAMIC_NETWORK_INFO[g_current_network_slot].chain_id,
                   chain_str,
                   sizeof(chain_str));
-    PRINTF("[NETWORK] - Registered in slot %d: %s (%s), for chain_id %s\n",
+    PRINTF("[NETWORK] - Registered in slot %u: \"%s\" (%s), for chain_id %s\n",
            g_current_network_slot,
            DYNAMIC_NETWORK_INFO[g_current_network_slot].name,
            DYNAMIC_NETWORK_INFO[g_current_network_slot].ticker,

--- a/src_features/provide_network_info/cmd_network_info.c
+++ b/src_features/provide_network_info/cmd_network_info.c
@@ -249,10 +249,6 @@ static bool handle_tlv_payload(const uint8_t *payload, uint16_t size, bool to_fr
     bool parsing_ret;
     s_network_info_ctx ctx = {0};
 
-    // Set the current slot here, because the corresponding icon will be received
-    // separately, after the network configuration, and should keep the same slot
-    g_current_network_slot = (g_current_network_slot + 1) % MAX_DYNAMIC_NETWORKS;
-
     // Initialize the hash context
     cx_sha256_init(&ctx.hash_ctx);
     parsing_ret = tlv_parse(payload, size, (f_tlv_data_handler) &handle_network_info_struct, &ctx);

--- a/src_features/provide_network_info/network_info.c
+++ b/src_features/provide_network_info/network_info.c
@@ -281,6 +281,11 @@ bool verify_network_info_struct(const s_network_info_ctx *context) {
                                     context->signature_length) != CX_OK) {
         return false;
     }
+
+    // Set the current slot here, because the corresponding icon will be received
+    // separately, after the network configuration, and should keep the same slot
+    g_current_network_slot = (g_current_network_slot + 1) % MAX_DYNAMIC_NETWORKS;
+
     memcpy(&DYNAMIC_NETWORK_INFO[g_current_network_slot],
            &context->network,
            sizeof(network_info_t));

--- a/src_features/provide_network_info/network_info.c
+++ b/src_features/provide_network_info/network_info.c
@@ -90,7 +90,6 @@ static bool handle_chain_id(const s_tlv_data *data, s_network_info_ctx *context)
     uint64_t chain_id;
     uint8_t buf[sizeof(chain_id)];
     uint64_t max_range;
-    uint8_t i;
 
     (void) context;
     if (data->length > sizeof(buf)) {
@@ -105,13 +104,6 @@ static bool handle_chain_id(const s_tlv_data *data, s_network_info_ctx *context)
     if ((chain_id > max_range) || (chain_id == 0)) {
         PRINTF("Unsupported chain ID: %u\n", chain_id);
         return false;
-    }
-    // Check if the chain_id is already registered
-    for (i = 0; i < MAX_DYNAMIC_NETWORKS; i++) {
-        if (DYNAMIC_NETWORK_INFO[i].chain_id == chain_id) {
-            PRINTF("CHAIN_ID already exist!\n");
-            return false;
-        }
     }
     context->network.chain_id = chain_id;
     return true;
@@ -280,6 +272,14 @@ bool verify_network_info_struct(const s_network_info_ctx *context) {
                                     (uint8_t *) context->signature,
                                     context->signature_length) != CX_OK) {
         return false;
+    }
+
+    // Check if the chain ID is already registered, if so delete it silently to prevent duplicates
+    for (int i = 0; i < MAX_DYNAMIC_NETWORKS; ++i) {
+        if (DYNAMIC_NETWORK_INFO[i].chain_id == context->network.chain_id) {
+            explicit_bzero(&DYNAMIC_NETWORK_INFO[i], sizeof(DYNAMIC_NETWORK_INFO[i]));
+            break;
+        }
     }
 
     // Set the current slot here, because the corresponding icon will be received


### PR DESCRIPTION
## Description

* Now the TLV payload is size prefixed, so if it ever grows bigger than the max size of an APDU, the APDU format will remain unchanged
* Now supports receiving the same network multiple times (was an issue when running the Ragger tests on device)
* Now the network info slot if left unchanged if the given network info is invalid

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [x] Documentation
- [x] Other (for changes that might not fit in any category)