### PR TITLE
Fix enum_value error handling

### DIFF
--- a/src_features/provide_enum_value/cmd_enum_value.c
+++ b/src_features/provide_enum_value/cmd_enum_value.c
@@ -8,13 +8,13 @@
 #include "tlv.h"
 
 bool handle_tlv_payload(const uint8_t *payload, uint16_t size, bool to_free) {
+    bool parsing_ret;
     s_enum_value_ctx ctx = {0};
 
     cx_sha256_init(&ctx.struct_hash);
-    if (!tlv_parse(payload, size, (f_tlv_data_handler) &handle_enum_value_struct, &ctx)) {
-        return false;
-    }
+    parsing_ret = tlv_parse(payload, size, (f_tlv_data_handler) &handle_enum_value_struct, &ctx);
     if (to_free) mem_dealloc(sizeof(size));
+    if (!parsing_ret) return false;
     if (!verify_enum_value_struct(&ctx)) {
         return false;
     }


### PR DESCRIPTION
## Description

A malformed enum_value payload would lead to a memory leak.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)