### PR TITLE
docs: Clarify address format in APDU docs

### DIFF
--- a/doc/ethapp.adoc
+++ b/doc/ethapp.adoc
@@ -88,7 +88,7 @@ _Output data_
 | Public Key length                                                                 | 1
 | Uncompressed Public Key                                                           | var
 | Ethereum address length                                                           | 1
-| Ethereum address                                                                  | var
+| ASCII-encoded Ethereum address                                                    | var
 | Chain code if requested                                                           | 32
 |==============================================================================================================================
 


### PR DESCRIPTION
## Description

Clarify that `GET ETH PUBLIC ADDRESS` APDU request returns ASCII-encoded address

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [x] Documentation
- [ ] Other (for changes that might not fit in any category)
