### PR TITLE
Update client to use Web3.py v7

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -16,19 +16,20 @@ readme = { file = "README.md", content-type = "text/markdown" }
 # license = { file = "LICENSE" }
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: POSIX :: Linux",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: MacOS :: MacOS X",
 ]
 dynamic = [ "version" ]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = [
     "ragger[speculos]",
-    "web3~=6.0",
+    "web3~=7.0",
 ]
 
 [tools.setuptools]

--- a/client/src/ledger_app_clients/ethereum/client.py
+++ b/client/src/ledger_app_clients/ethereum/client.py
@@ -219,7 +219,7 @@ class EthAppClient:
         if tx_raw is not None:
             tx = tx_raw
         else:
-            tx = Web3().eth.account.create().sign_transaction(tx_params).rawTransaction
+            tx = Web3().eth.account.create().sign_transaction(tx_params).raw_transaction
         prefix = bytes()
         suffix = []
         if tx[0] in [0x01, 0x02, 0x04]:

--- a/client/src/ledger_app_clients/ethereum/client.py
+++ b/client/src/ledger_app_clients/ethereum/client.py
@@ -213,13 +213,10 @@ class EthAppClient:
     def eip712_filtering_raw(self, name: str, sig: bytes, discarded: bool):
         return self._exchange_async(self._cmd_builder.eip712_filtering_raw(name, sig, discarded))
 
-    def serialize_tx(self, tx_params: dict, tx_raw: Optional[bytes] = None) -> tuple[bytes, bytes]:
+    def serialize_tx(self, tx_params: dict) -> tuple[bytes, bytes]:
         """Computes the serialized TX and its hash"""
 
-        if tx_raw is not None:
-            tx = tx_raw
-        else:
-            tx = Web3().eth.account.create().sign_transaction(tx_params).raw_transaction
+        tx = Web3().eth.account.create().sign_transaction(tx_params).raw_transaction
         prefix = bytes()
         suffix = []
         if tx[0] in [0x01, 0x02, 0x04]:
@@ -228,10 +225,7 @@ class EthAppClient:
         else:  # legacy
             if "chainId" in tx_params:
                 suffix = [int(tx_params["chainId"]), bytes(), bytes()]
-        if tx_raw is None:
-            decoded_tx = rlp.decode(tx)[:-3]  # remove already computed signature
-        else:
-            decoded_tx = rlp.decode(tx)
+        decoded_tx = rlp.decode(tx)[:-3]  # remove already computed signature
         encoded_tx = prefix + rlp.encode(decoded_tx + suffix)
         tx_hash = keccak(encoded_tx)
         return encoded_tx, tx_hash
@@ -239,9 +233,8 @@ class EthAppClient:
     def sign(self,
              bip32_path: str,
              tx_params: dict,
-             tx_raw: Optional[bytes] = None,  # Introduced for 7702 until web3.py supports authorization lists
              mode: SignMode = SignMode.BASIC):
-        tx, _ = self.serialize_tx(tx_params, tx_raw)
+        tx, _ = self.serialize_tx(tx_params)
         chunks = self._cmd_builder.sign(bip32_path, tx, mode)
         for chunk in chunks[:-1]:
             self._exchange(chunk)

--- a/client/src/ledger_app_clients/ethereum/client.py
+++ b/client/src/ledger_app_clients/ethereum/client.py
@@ -1,6 +1,6 @@
 import struct
 from enum import IntEnum
-from typing import Optional, Tuple
+from typing import Optional
 from hashlib import sha256
 import rlp
 from web3 import Web3
@@ -213,7 +213,7 @@ class EthAppClient:
     def eip712_filtering_raw(self, name: str, sig: bytes, discarded: bool):
         return self._exchange_async(self._cmd_builder.eip712_filtering_raw(name, sig, discarded))
 
-    def serialize_tx(self, tx_params: dict, tx_raw: Optional[bytes] = None) -> Tuple[bytes, bytes]:
+    def serialize_tx(self, tx_params: dict, tx_raw: Optional[bytes] = None) -> tuple[bytes, bytes]:
         """Computes the serialized TX and its hash"""
 
         if tx_raw is not None:
@@ -338,7 +338,7 @@ class EthAppClient:
                                 chain_id: int,
                                 nft_id: Optional[int] = None,
                                 challenge: Optional[int] = None,
-                                not_valid_after: Optional[Tuple[int]] = None) -> RAPDU:
+                                not_valid_after: Optional[tuple[int, int, int]] = None) -> RAPDU:
         payload = format_tlv(FieldTag.STRUCT_VERSION, 2)
         payload += format_tlv(FieldTag.TRUSTED_NAME, name)
         payload += format_tlv(FieldTag.ADDRESS, addr)

--- a/client/src/ledger_app_clients/ethereum/response_parser.py
+++ b/client/src/ledger_app_clients/ethereum/response_parser.py
@@ -1,11 +1,11 @@
-def signature(data: bytes) -> tuple[bytes, bytes, bytes]:
+def signature(data: bytes) -> tuple[int, int, int]:
     assert len(data) == (1 + 32 + 32)
 
-    v = data[0:1]
+    v = int.from_bytes(data[0:1], "big")
     data = data[1:]
-    r = data[0:32]
+    r = int.from_bytes(data[0:32], "big")
     data = data[32:]
-    s = data[0:32]
+    s = int.from_bytes(data[0:32], "big")
 
     return v, r, s
 

--- a/client/src/ledger_app_clients/ethereum/utils.py
+++ b/client/src/ledger_app_clients/ethereum/utils.py
@@ -9,7 +9,7 @@ def get_selector_from_data(data: str) -> bytes:
     return raw_data[:4]
 
 
-def recover_message(msg, vrs: tuple) -> bytes:
+def recover_message(msg, vrs: tuple[int, int, int]) -> bytes:
     if isinstance(msg, dict):  # EIP-712
         smsg = encode_typed_data(full_message=msg)
     else:  # EIP-191
@@ -18,7 +18,7 @@ def recover_message(msg, vrs: tuple) -> bytes:
     return bytes.fromhex(addr[2:])
 
 
-def recover_transaction(tx_params, vrs: tuple, raw_tx_param: Optional[bytes] = None) -> bytes:
+def recover_transaction(tx_params, vrs: tuple[int, int, int], raw_tx_param: Optional[bytes] = None) -> bytes:
     if raw_tx_param is None:
         raw_tx = Account.create().sign_transaction(tx_params).raw_transaction
     else:

--- a/client/src/ledger_app_clients/ethereum/utils.py
+++ b/client/src/ledger_app_clients/ethereum/utils.py
@@ -28,7 +28,7 @@ def recover_message(msg, vrs: tuple) -> bytes:
 
 def recover_transaction(tx_params, vrs: tuple, raw_tx_param: Optional[bytes] = None) -> bytes:
     if raw_tx_param is None:
-        raw_tx = Account.create().sign_transaction(tx_params).rawTransaction
+        raw_tx = Account.create().sign_transaction(tx_params).raw_transaction
     else:
         raw_tx = raw_tx_param
     prefix = bytes()

--- a/tests/ragger/requirements.txt
+++ b/tests/ragger/requirements.txt
@@ -1,5 +1,5 @@
 pytest
 ecdsa
-web3~=6.0
+web3~=7.0
 ragger[speculos]
 py_ecc

--- a/tests/ragger/test_eip7702.py
+++ b/tests/ragger/test_eip7702.py
@@ -36,9 +36,9 @@ def common(firmware: Firmware,
            delegate: bytes,
            nonce: int,
            chain_id: int,
-           v: bytes = None,
-           r: bytes = None,
-           s: bytes = None):
+           v: int = None,
+           r: int = None,
+           s: int = None):
 
     app_client = EthAppClient(backend)
 
@@ -96,9 +96,9 @@ def test_eip7702_in_whitelist(firmware: Firmware,
            TEST_ADDRESS_1,
            NONCE,
            CHAIN_ID_1,
-           bytes.fromhex("00"),
-           bytes.fromhex("f82e 50a7 55fa 989f 4bb9 b36b 15af b442 4ce9 cda6 9752 fd17 a7eb 1473 7d96 3e62"),
-           bytes.fromhex("07c9 c91d 6140 b45e a52f 29de 7a5e ffb9 dd34 0607 a26e 225c 4027 8e91 c405 4492"))
+           0x00,
+           0xf82e50a755fa989f4bb9b36b15afb4424ce9cda69752fd17a7eb14737d963e62,
+           0x07c9c91d6140b45ea52f29de7a5effb9dd340607a26e225c40278e91c4054492)
 
 
 def test_eip7702_in_whitelist_all_chain_whitelisted(firmware: Firmware,
@@ -115,9 +115,9 @@ def test_eip7702_in_whitelist_all_chain_whitelisted(firmware: Firmware,
            TEST_ADDRESS_0,
            NONCE,
            CHAIN_ID_2,
-           bytes.fromhex("00"),
-           bytes.fromhex("0378 f7ac 482e c728 b65d 19d0 3943 bbb3 fe73 07c7 2c64 6e7d 2d0c 11be e81e b2b9"),
-           bytes.fromhex("3322 66ec 3ef9 96bf 835c 50a8 3300 6b4c 8039 8d59 7d0e 6846 19db 4d51 a384 a38d"))
+           0x00,
+           0x0378f7ac482ec728b65d19d03943bbb3fe7307c72c646e7d2d0c11bee81eb2b9,
+           0x332266ec3ef996bf835c50a833006b4c80398d597d0e684619db4d51a384a38d)
 
 
 def test_eip7702_in_whitelist_all_chain_param(firmware: Firmware,
@@ -134,9 +134,9 @@ def test_eip7702_in_whitelist_all_chain_param(firmware: Firmware,
            TEST_ADDRESS_2,
            NONCE,
            CHAIN_ID_0,
-           bytes.fromhex("01"),
-           bytes.fromhex("a24f 35ca fc6b 408c e325 39d4 bd89 a67e dd4d 6303 fc67 6dfd df93 b984 05b7 ee5e"),
-           bytes.fromhex("1594 56ba be65 6692 959c a3d8 29ca 269e 8f82 387c 91e4 0a33 633d 190d da7a 3c5c"))
+           0x01,
+           0xa24f35cafc6b408ce32539d4bd89a67edd4d6303fc676dfddf93b98405b7ee5e,
+           0x159456babe656692959ca3d829ca269e8f82387c91e40a33633d190dda7a3c5c)
 
 
 def test_eip7702_in_whitelist_max(firmware: Firmware,
@@ -153,9 +153,9 @@ def test_eip7702_in_whitelist_max(firmware: Firmware,
            TEST_ADDRESS_MAX,
            NONCE_MAX,
            CHAIN_ID_MAX,
-           bytes.fromhex("00"),
-           bytes.fromhex("a07c 6808 9449 8c21 e80f ebb0 11ae 5d62 ede6 645d 77d7 c902 db06 5d5a 082d d220"),
-           bytes.fromhex("6b5c 6222 5cf6 5a62 40c2 583d acc1 641c 8d69 2ed3 bd00 473c c3e2 8fe1 a4f5 2294"))
+           0x00,
+           0xa07c680894498c21e80febb011ae5d62ede6645d77d7c902db065d5a082dd220,
+           0x6b5c62225cf65a6240c2583dacc1641c8d692ed3bd00473cc3e28fe1a4f52294)
 
 
 def test_eip7702_in_whitelist_wrong_chain(firmware: Firmware,

--- a/tests/ragger/test_sign.py
+++ b/tests/ragger/test_sign.py
@@ -389,6 +389,6 @@ def test_sign_eip_7702(firmware: Firmware,
            test_name=test_name,
            path=BIP32_PATH,
            with_simu=False,
-           v=bytes.fromhex("01"),
-           r=bytes.fromhex("9800ce04ecb46aebde0fea80c66392255eb13c3b3597aeec222447f6e1bfcfaf"),
-           s=bytes.fromhex("787eb82581e1a51d8956f21a0ccd0b96d8de14b04c11de0b7dcb5e400219902b"))
+           v=0x01,
+           r=0x9800ce04ecb46aebde0fea80c66392255eb13c3b3597aeec222447f6e1bfcfaf,
+           s=0x787eb82581e1a51d8956f21a0ccd0b96d8de14b04c11de0b7dcb5e400219902b)

--- a/tests/ragger/test_sign.py
+++ b/tests/ragger/test_sign.py
@@ -12,7 +12,7 @@ from ragger.navigator.navigation_scenario import NavigateWithScenario
 from client.client import EthAppClient, StatusWord
 import client.response_parser as ResponseParser
 from client.settings import SettingID, settings_toggle
-from client.utils import recover_transaction
+from client.utils import recover_transaction, get_authorization_obj
 
 
 # Values used across all tests
@@ -38,13 +38,9 @@ def common(firmware: Firmware,
            scenario_navigator: NavigateWithScenario,
            default_screenshot_path: Path,
            tx_params: dict,
-           tx_raw: bytes = None,
            test_name: str = "",
            path: str = BIP32_PATH,
-           with_simu: bool = False,
-           v: bytes = None,
-           r: bytes = None,
-           s: bytes = None):
+           with_simu: bool = False):
     app_client = EthAppClient(backend)
 
     if tx_params["chainId"] == 3:
@@ -71,7 +67,7 @@ def common(firmware: Firmware,
         pass
     _, DEVICE_ADDR, _ = ResponseParser.pk_addr(app_client.response().data)
 
-    with app_client.sign(path, tx_params, tx_raw):
+    with app_client.sign(path, tx_params):
         if with_simu:
             navigator.navigate_and_compare(default_screenshot_path,
                                            f"{test_name}/warning",
@@ -85,17 +81,8 @@ def common(firmware: Firmware,
 
     # verify signature
     vrs = ResponseParser.signature(app_client.response().data)
-    if v is not None:  # temporary until web3.py supports 7702
-        print(vrs)
-        print(v)
-        print(r)
-        print(s)
-        assert v == vrs[0]
-        assert r == vrs[1]
-        assert s == vrs[2]
-    else:
-        addr = recover_transaction(tx_params, vrs, tx_raw)
-        assert addr == DEVICE_ADDR
+    addr = recover_transaction(tx_params, vrs)
+    assert addr == DEVICE_ADDR
 
 
 def common_reject(backend: BackendInterface,
@@ -376,19 +363,26 @@ def test_sign_eip_7702(firmware: Firmware,
     if firmware == Firmware.NANOS:
         pytest.skip("Not supported on LNS")
     tx_params = {
-        "chainId": 1
+        "chainId": 1,
+        "nonce": 1337,
+        "maxPriorityFeePerGas": 0x01,
+        "maxFeePerGas": 0x01,
+        "gas": 21000,
+        "to": bytes.fromhex("1212121212121212121212121212121212121212"),
+        "value": Web3.to_wei(0.01, "ether"),
+        "authorizationList": [
+            get_authorization_obj(0, 1337, bytes.fromhex("1212121212121212121212121212121212121212"), (
+                0x01,
+                0xa24f35cafc6b408ce32539d4bd89a67edd4d6303fc676dfddf93b98405b7ee5e,
+                0x159456babe656692959ca3d829ca269e8f82387c91e40a33633d190dda7a3c5c,
+            ))
+        ],
     }
-    tx_raw = bytes.fromhex("04f888018205390101825208941212121212121212121212121212121212121212872386f26fc1000080c0f85ef85c8094020202020202020202020202020202020202020282053901a0a24f35cafc6b408ce32539d4bd89a67edd4d6303fc676dfddf93b98405b7ee5ea0159456babe656692959ca3d829ca269e8f82387c91e40a33633d190dda7a3c5c")
     common(firmware,
            backend,
            navigator,
            scenario_navigator,
            default_screenshot_path,
            tx_params,
-           tx_raw,
            test_name=test_name,
-           path=BIP32_PATH,
-           with_simu=False,
-           v=0x01,
-           r=0x9800ce04ecb46aebde0fea80c66392255eb13c3b3597aeec222447f6e1bfcfaf,
-           s=0x787eb82581e1a51d8956f21a0ccd0b96d8de14b04c11de0b7dcb5e400219902b)
+           path=BIP32_PATH)

--- a/tests/ragger/test_sign.py
+++ b/tests/ragger/test_sign.py
@@ -81,11 +81,11 @@ def common(firmware: Firmware,
             end_text = "Accept"
         else:
             end_text = r"(Sign|Accept (risk|threat))"
-        scenario_navigator.review_approve(test_name=test_name, custom_screen_text=end_text, do_comparison=test_name!="")
+        scenario_navigator.review_approve(test_name=test_name, custom_screen_text=end_text, do_comparison=test_name != "")
 
     # verify signature
     vrs = ResponseParser.signature(app_client.response().data)
-    if v is not None: # temporary until web3.py supports 7702
+    if v is not None:  # temporary until web3.py supports 7702
         print(vrs)
         print(v)
         print(r)
@@ -174,7 +174,14 @@ def test_sign_legacy_send_bsc(firmware: Firmware,
         "value": Web3.to_wei(AMOUNT2, "ether"),
         "chainId": 56
     }
-    common(firmware, backend, navigator, scenario_navigator, default_screenshot_path, tx_params, None, test_name, BIP32_PATH2)
+    common(firmware,
+           backend,
+           navigator,
+           scenario_navigator,
+           default_screenshot_path,
+           tx_params,
+           test_name=test_name,
+           path=BIP32_PATH2)
 
 
 # Transfer on network 112233445566 on Ethereum
@@ -192,7 +199,14 @@ def test_sign_legacy_chainid(firmware: Firmware,
         "value": Web3.to_wei(AMOUNT2, "ether"),
         "chainId": 112233445566
     }
-    common(firmware, backend, navigator, scenario_navigator, default_screenshot_path, tx_params, None, test_name, BIP32_PATH2)
+    common(firmware,
+           backend,
+           navigator,
+           scenario_navigator,
+           default_screenshot_path,
+           tx_params,
+           test_name=test_name,
+           path=BIP32_PATH2)
 
 
 def test_1559(firmware: Firmware,
@@ -232,9 +246,8 @@ def test_sign_simple(firmware: Firmware,
            scenario_navigator,
            default_screenshot_path,
            tx_params,
-           None,
-           test_name,
-           BIP32_PATH2)
+           test_name=test_name,
+           path=BIP32_PATH2)
 
 
 def test_sign_limit_nonce(firmware: Firmware,
@@ -257,9 +270,8 @@ def test_sign_limit_nonce(firmware: Firmware,
            scenario_navigator,
            default_screenshot_path,
            tx_params,
-           None,
-           test_name,
-           BIP32_PATH2)
+           test_name=test_name,
+           path=BIP32_PATH2)
 
 
 def test_sign_nonce_display(firmware: Firmware,
@@ -285,9 +297,9 @@ def test_sign_nonce_display(firmware: Firmware,
            scenario_navigator,
            default_screenshot_path,
            tx_params,
-           None,
-           test_name,
-           BIP32_PATH2)
+           test_name=test_name,
+           path=BIP32_PATH2)
+
 
 def test_sign_reject(backend: BackendInterface, scenario_navigator: NavigateWithScenario):
     tx_params: dict = {
@@ -352,8 +364,8 @@ def test_sign_eip_2930(firmware: Firmware,
            scenario_navigator,
            default_screenshot_path,
            tx_params,
-           None,
-           test_name)
+           test_name=test_name)
+
 
 def test_sign_eip_7702(firmware: Firmware,
                        backend: BackendInterface,
@@ -364,11 +376,19 @@ def test_sign_eip_7702(firmware: Firmware,
     if firmware == Firmware.NANOS:
         pytest.skip("Not supported on LNS")
     tx_params = {
-        "chainId" : 1
+        "chainId": 1
     }
     tx_raw = bytes.fromhex("04f888018205390101825208941212121212121212121212121212121212121212872386f26fc1000080c0f85ef85c8094020202020202020202020202020202020202020282053901a0a24f35cafc6b408ce32539d4bd89a67edd4d6303fc676dfddf93b98405b7ee5ea0159456babe656692959ca3d829ca269e8f82387c91e40a33633d190dda7a3c5c")
-    common(firmware, backend, navigator, scenario_navigator, default_screenshot_path, tx_params, tx_raw, test_name,
-        BIP32_PATH, False,
-        bytes.fromhex("01"),
-        bytes.fromhex("9800 ce04 ecb4 6aeb de0f ea80 c663 9225 5eb1 3c3b 3597 aeec 2224 47f6 e1bf cfaf"),
-        bytes.fromhex("787e b825 81e1 a51d 8956 f21a 0ccd 0b96 d8de 14b0 4c11 de0b 7dcb 5e40 0219 902b"))
+    common(firmware,
+           backend,
+           navigator,
+           scenario_navigator,
+           default_screenshot_path,
+           tx_params,
+           tx_raw,
+           test_name=test_name,
+           path=BIP32_PATH,
+           with_simu=False,
+           v=bytes.fromhex("01"),
+           r=bytes.fromhex("9800ce04ecb46aebde0fea80c66392255eb13c3b3597aeec222447f6e1bfcfaf"),
+           s=bytes.fromhex("787eb82581e1a51d8956f21a0ccd0b96d8de14b04c11de0b7dcb5e400219902b"))


### PR DESCRIPTION
## Description

EIP-7702 tests benefit greatly from this newer Web3.py version.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [x] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)