### PR TITLE
Migration to the SDK memory allocator

### DIFF
--- a/makefile_conf/features.mk
+++ b/makefile_conf/features.mk
@@ -52,6 +52,14 @@ ifneq ($(EIP7702_TEST_WHITELIST),0)
     DEFINES += HAVE_EIP7702_WHITELIST_TEST
 endif
 
+ENABLE_DYNAMIC_ALLOC = 1
+ifneq ($(DEBUG), 0)
+    MEMORY_PROFILING ?= 0
+    ifneq ($(MEMORY_PROFILING),0)
+        DEFINES += HAVE_MEMORY_PROFILING
+    endif
+endif
+
 # Check features incompatibilities
 # --------------------------------
 # NFTs

--- a/src/main.c
+++ b/src/main.c
@@ -381,7 +381,7 @@ void coin_main(eth_libargs_t *args) {
 
     io_init();
     ui_idle();
-    mem_legacy_init();
+    app_mem_init();
 
     // to prevent it from having a fixed value at boot
     roll_challenge();

--- a/src/main.c
+++ b/src/main.c
@@ -381,7 +381,7 @@ void coin_main(eth_libargs_t *args) {
 
     io_init();
     ui_idle();
-    mem_init();
+    mem_legacy_init();
 
     // to prevent it from having a fixed value at boot
     roll_challenge();

--- a/src/mem.c
+++ b/src/mem.c
@@ -13,22 +13,22 @@
 #define SIZE_MEM_BUFFER 10240
 
 static uint8_t mem_buffer[SIZE_MEM_BUFFER];
-static uint16_t mem_idx;
-static uint16_t mem_rev_idx;
+static uint16_t mem_legacy_idx;
+static uint16_t mem_legacy_rev_idx;
 
 /**
  * Initializes the memory buffer index
  */
-void mem_init(void) {
-    mem_idx = 0;
-    mem_rev_idx = 0;
+void mem_legacy_init(void) {
+    mem_legacy_idx = 0;
+    mem_legacy_rev_idx = 0;
 }
 
 /**
  * Resets the memory buffer index
  */
-void mem_reset(void) {
-    mem_init();
+void mem_legacy_reset(void) {
+    mem_legacy_init();
 }
 
 /**
@@ -40,12 +40,12 @@ void mem_reset(void) {
  * @param[in] size Requested allocation size in bytes
  * @return Allocated memory pointer; \ref NULL if not enough space left.
  */
-void *mem_alloc(size_t size) {
+void *mem_legacy_alloc(size_t size) {
     size_t new_idx;
     size_t free_size;
 
-    if (__builtin_add_overflow((size_t) mem_idx, size, &new_idx) ||
-        __builtin_sub_overflow(sizeof(mem_buffer), (size_t) mem_rev_idx, &free_size)) {
+    if (__builtin_add_overflow((size_t) mem_legacy_idx, size, &new_idx) ||
+        __builtin_sub_overflow(sizeof(mem_buffer), (size_t) mem_legacy_rev_idx, &free_size)) {
         PRINTF("Error: overflow detected!\n");
         return NULL;
     }
@@ -54,8 +54,8 @@ void *mem_alloc(size_t size) {
         PRINTF("Error: mem_alloc(%u) failed!\n", size);
         return NULL;
     }
-    mem_idx += size;
-    return &mem_buffer[mem_idx - size];
+    mem_legacy_idx += size;
+    return &mem_buffer[mem_legacy_idx - size];
 }
 
 /**
@@ -63,13 +63,13 @@ void *mem_alloc(size_t size) {
  *
  * @param[in] size Requested deallocation size in bytes
  */
-void mem_dealloc(size_t size) {
+void mem_legacy_dealloc(size_t size) {
     // More than is already allocated
-    if (size > mem_idx) {
+    if (size > mem_legacy_idx) {
         PRINTF("Warning: mem_dealloc(%u) with a value larger than allocated!\n", size);
-        mem_idx = 0;
+        mem_legacy_idx = 0;
     } else {
-        mem_idx -= size;
+        mem_legacy_idx -= size;
     }
 }
 
@@ -79,22 +79,22 @@ void mem_dealloc(size_t size) {
  * @param[in] size Requested allocation size in bytes
  * @return Allocated memory pointer; \ref NULL if not enough space left.
  */
-void *mem_rev_alloc(size_t size) {
+void *mem_legacy_rev_alloc(size_t size) {
     size_t free_size;
     size_t new_rev_idx;
 
-    if (__builtin_add_overflow((size_t) mem_rev_idx, size, &new_rev_idx) ||
+    if (__builtin_add_overflow((size_t) mem_legacy_rev_idx, size, &new_rev_idx) ||
         __builtin_sub_overflow(sizeof(mem_buffer), new_rev_idx, &free_size)) {
         PRINTF("Error: overflow detected!\n");
         return NULL;
     }
     // Buffer exceeded
-    if (free_size < mem_idx) {
+    if (free_size < mem_legacy_idx) {
         PRINTF("Error: mem_rev_alloc(%u) failed!\n", size);
         return NULL;
     }
-    mem_rev_idx += size;
-    return &mem_buffer[sizeof(mem_buffer) - mem_rev_idx];
+    mem_legacy_rev_idx += size;
+    return &mem_buffer[sizeof(mem_buffer) - mem_legacy_rev_idx];
 }
 
 /**
@@ -102,12 +102,12 @@ void *mem_rev_alloc(size_t size) {
  *
  * @param[in] size Requested deallocation size in bytes
  */
-void mem_rev_dealloc(size_t size) {
+void mem_legacy_rev_dealloc(size_t size) {
     // More than is already allocated
-    if (size > mem_rev_idx) {
+    if (size > mem_legacy_rev_idx) {
         PRINTF("Warning: mem_rev_dealloc(%u) with a value larger than allocated!\n", size);
-        mem_rev_idx = 0;
+        mem_legacy_rev_idx = 0;
     } else {
-        mem_rev_idx -= size;
+        mem_legacy_rev_idx -= size;
     }
 }

--- a/src/mem.c
+++ b/src/mem.c
@@ -11,7 +11,9 @@
 #include "mem_alloc.h"
 #include "os_print.h"
 
-#define SIZE_MEM_BUFFER 10240
+#define SIZE_MEM_BUFFER_MAIN 10240
+#define SIZE_MEM_BUFFER_ALT  2048
+#define SIZE_MEM_BUFFER      (SIZE_MEM_BUFFER_MAIN + SIZE_MEM_BUFFER_ALT)
 
 static uint8_t mem_buffer[SIZE_MEM_BUFFER] __attribute__((aligned(8)));
 static uint16_t mem_legacy_idx;
@@ -49,6 +51,8 @@ void app_mem_free_impl(void *ptr, const char *file, int line) {
  */
 void mem_legacy_init(void) {
     mem_legacy_idx = 0;
+    // initialize the new allocator to still be able to use it, just in case
+    mem_ctx = mem_init(mem_buffer + SIZE_MEM_BUFFER_MAIN, SIZE_MEM_BUFFER_ALT);
 }
 
 /**
@@ -75,7 +79,7 @@ void *mem_legacy_alloc(size_t size) {
         return NULL;
     }
     // Buffer exceeded
-    if (new_idx > sizeof(mem_buffer)) {
+    if (new_idx > SIZE_MEM_BUFFER_MAIN) {
         PRINTF("Error: mem_alloc(%u) failed!\n", size);
         return NULL;
     }

--- a/src/mem.h
+++ b/src/mem.h
@@ -2,9 +2,9 @@
 
 #include <stdlib.h>
 
-void mem_init(void);
-void mem_reset(void);
-void *mem_alloc(size_t size);
-void mem_dealloc(size_t size);
-void *mem_rev_alloc(size_t size);
-void mem_rev_dealloc(size_t size);
+void mem_legacy_init(void);
+void mem_legacy_reset(void);
+void *mem_legacy_alloc(size_t size);
+void mem_legacy_dealloc(size_t size);
+void *mem_legacy_rev_alloc(size_t size);
+void mem_legacy_rev_dealloc(size_t size);

--- a/src/mem.h
+++ b/src/mem.h
@@ -1,6 +1,21 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stdlib.h>
+
+#ifdef HAVE_MEMORY_PROFILING
+#define MP_FILE __FILE__
+#define MP_LINE __LINE__
+#else
+#define MP_FILE NULL
+#define MP_LINE 0
+#endif
+#define app_mem_alloc(size) app_mem_alloc_impl(size, MP_FILE, MP_LINE)
+#define app_mem_free(ptr)   app_mem_free_impl(ptr, MP_FILE, MP_LINE)
+
+bool app_mem_init(void);
+void *app_mem_alloc_impl(size_t size, const char *file, int line);
+void app_mem_free_impl(void *ptr, const char *file, int line);
 
 void mem_legacy_init(void);
 void mem_legacy_reset(void);

--- a/src/mem.h
+++ b/src/mem.h
@@ -21,5 +21,3 @@ void mem_legacy_init(void);
 void mem_legacy_reset(void);
 void *mem_legacy_alloc(size_t size);
 void mem_legacy_dealloc(size_t size);
-void *mem_legacy_rev_alloc(size_t size);
-void mem_legacy_rev_dealloc(size_t size);

--- a/src/mem_utils.c
+++ b/src/mem_utils.c
@@ -12,7 +12,7 @@
  *
  * @return pointer to memory area or \ref NULL if the allocation failed
  */
-char *mem_alloc_and_format_uint(uint32_t value, uint8_t *const length) {
+char *mem_legacy_alloc_and_format_uint(uint32_t value, uint8_t *const length) {
     char *mem_ptr;
     uint32_t value_copy;
     uint8_t size;
@@ -24,9 +24,9 @@ char *mem_alloc_and_format_uint(uint32_t value, uint8_t *const length) {
         size += 1;
     }
     // +1 for the null character
-    if ((mem_ptr = mem_alloc(sizeof(char) * (size + 1)))) {
+    if ((mem_ptr = mem_legacy_alloc(sizeof(char) * (size + 1)))) {
         snprintf(mem_ptr, (size + 1), "%u", value);
-        mem_dealloc(sizeof(char));  // to skip the null character
+        mem_legacy_dealloc(sizeof(char));  // to skip the null character
         if (length != NULL) {
             *length = size;
         }
@@ -40,12 +40,12 @@ char *mem_alloc_and_format_uint(uint32_t value, uint8_t *const length) {
  * @param[in] alignment given alignment value
  * @return size of the padding required for proper alignment
  */
-uint8_t mem_align(size_t alignment) {
-    uint8_t diff = (uintptr_t) mem_alloc(0) % alignment;
+uint8_t mem_legacy_align(size_t alignment) {
+    uint8_t diff = (uintptr_t) mem_legacy_alloc(0) % alignment;
 
     if (diff > 0) {
         diff = alignment - diff;
-        mem_alloc(diff);
+        mem_legacy_alloc(diff);
     }
     return diff;
 }
@@ -59,7 +59,7 @@ uint8_t mem_align(size_t alignment) {
  *
  * @return pointer to the memory area, \ref NULL if the allocation failed
  */
-void *mem_alloc_and_align(size_t size, size_t alignment) {
-    mem_align(alignment);
-    return mem_alloc(size);
+void *mem_legacy_alloc_and_align(size_t size, size_t alignment) {
+    mem_legacy_align(alignment);
+    return mem_legacy_alloc(size);
 }

--- a/src/mem_utils.h
+++ b/src/mem_utils.h
@@ -2,8 +2,8 @@
 
 #include <stdint.h>
 
-#define MEM_ALLOC_AND_ALIGN_TYPE(type) mem_alloc_and_align(sizeof(type), __alignof__(type))
+#define MEM_ALLOC_AND_ALIGN_TYPE(type) mem_legacy_alloc_and_align(sizeof(type), __alignof__(type))
 
-char *mem_alloc_and_format_uint(uint32_t value, uint8_t *const written_chars);
-uint8_t mem_align(size_t alignment);
-void *mem_alloc_and_align(size_t size, size_t alignment);
+char *mem_legacy_alloc_and_format_uint(uint32_t value, uint8_t *const written_chars);
+uint8_t mem_legacy_align(size_t alignment);
+void *mem_legacy_alloc_and_align(size_t size, size_t alignment);

--- a/src/tlv_apdu.c
+++ b/src/tlv_apdu.c
@@ -11,7 +11,7 @@ static bool g_dyn = false;
 
 static void reset_state(bool free) {
     if ((g_tlv_payload != NULL) && free) {
-        mem_dealloc(g_tlv_size);
+        mem_legacy_dealloc(g_tlv_size);
     }
     g_tlv_payload = NULL;
     g_tlv_size = 0;
@@ -42,7 +42,7 @@ bool tlv_from_apdu(bool first_chunk,
             }
 
             g_dyn = true;
-            g_tlv_payload = mem_alloc(g_tlv_size);
+            g_tlv_payload = mem_legacy_alloc(g_tlv_size);
         } else {
             g_dyn = false;
         }

--- a/src/tlv_apdu.c
+++ b/src/tlv_apdu.c
@@ -11,7 +11,7 @@ static bool g_dyn = false;
 
 static void reset_state(bool free) {
     if ((g_tlv_payload != NULL) && free) {
-        mem_legacy_dealloc(g_tlv_size);
+        app_mem_free(g_tlv_payload);
     }
     g_tlv_payload = NULL;
     g_tlv_size = 0;
@@ -42,7 +42,7 @@ bool tlv_from_apdu(bool first_chunk,
             }
 
             g_dyn = true;
-            g_tlv_payload = mem_legacy_alloc(g_tlv_size);
+            g_tlv_payload = app_mem_alloc(g_tlv_size);
         } else {
             g_dyn = false;
         }
@@ -65,8 +65,8 @@ bool tlv_from_apdu(bool first_chunk,
     g_tlv_pos += chunk_length;
 
     if (g_tlv_pos == g_tlv_size) {
-        ret = (*handler)(g_dyn ? g_tlv_payload : &payload[offset], g_tlv_size, g_dyn);
-        reset_state(false);  // already deallocated in the handler
+        ret = (*handler)(g_dyn ? g_tlv_payload : &payload[offset], g_tlv_size);
+        reset_state(g_dyn);
     }
     return ret;
 }

--- a/src/tlv_apdu.h
+++ b/src/tlv_apdu.h
@@ -3,7 +3,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-typedef bool (*f_tlv_payload_handler)(const uint8_t *payload, uint16_t size, bool to_free);
+typedef bool (*f_tlv_payload_handler)(const uint8_t *payload, uint16_t size);
 
 bool tlv_from_apdu(bool first_chunk,
                    uint8_t lc,

--- a/src_features/generic_tx_parser/calldata.c
+++ b/src_features/generic_tx_parser/calldata.c
@@ -5,50 +5,36 @@
 #include "mem.h"
 #include "mem_utils.h"
 
-typedef struct {
-    uint8_t selector[CALLDATA_SELECTOR_SIZE];
-    // chunk_info (8 bit):
-    // ........
-    //   ^^^^^^ byte size
-    //  ^ unused
-    // ^ strip direction : 0 LEFT, 1 RIGHT
-    //
-    // chunk_info (1) | chunk (n) | chunk info (1) | chunk (n) | ...
-    uint8_t *chunks;
-    size_t chunks_size;
-    size_t expected_size;
-    size_t received_size;
-    uint8_t chunk[CALLDATA_CHUNK_SIZE];
-    size_t chunk_size;
-} s_calldata;
-
-static s_calldata *g_calldata = NULL;
-static uint8_t g_calldata_alignment;
-
 typedef enum {
     CHUNK_STRIP_LEFT = 0,
     CHUNK_STRIP_RIGHT = 1,
 } e_chunk_strip_dir;
 
-#define CHUNK_INFO_SIZE_MASK   0x3f
-#define CHUNK_INFO_SIZE_OFFSET 0
+typedef struct calldata_chunk {
+    e_chunk_strip_dir dir : 1;
+    uint8_t size : 7;
+    uint8_t *buf;
+    struct calldata_chunk *next;
+} s_calldata_chunk;
 
-#define CHUNK_INFO_DIR_MASK   0x01
-#define CHUNK_INFO_DIR_OFFSET 7
+typedef struct {
+    size_t expected_size;
+    size_t received_size;
 
-#define CHUNK_INFO_SIZE(v) \
-    ((v & (CHUNK_INFO_SIZE_MASK << CHUNK_INFO_SIZE_OFFSET)) >> CHUNK_INFO_SIZE_OFFSET)
-#define CHUNK_INFO_DIR(v) \
-    ((v & (CHUNK_INFO_DIR_MASK << CHUNK_INFO_DIR_OFFSET)) >> CHUNK_INFO_DIR_OFFSET)
+    uint8_t selector[CALLDATA_SELECTOR_SIZE];
+    s_calldata_chunk *chunks;  // linked list
 
-typedef uint8_t chunk_info_t;
+    uint8_t chunk[CALLDATA_CHUNK_SIZE];
+    size_t chunk_size;
+} s_calldata;
+
+static s_calldata *g_calldata = NULL;
 
 bool calldata_init(size_t size) {
     if (g_calldata != NULL) {
         calldata_cleanup();
     }
-    g_calldata_alignment = mem_legacy_align(__alignof__(*g_calldata));
-    if ((g_calldata = mem_legacy_alloc(sizeof(*g_calldata))) == NULL) {
+    if ((g_calldata = app_mem_alloc(sizeof(*g_calldata))) == NULL) {
         return false;
     }
     explicit_bzero(g_calldata, sizeof(*g_calldata));
@@ -59,59 +45,55 @@ bool calldata_init(size_t size) {
 static bool compress_chunk(s_calldata *calldata) {
     uint8_t strip_left = 0;
     uint8_t strip_right = 0;
-    chunk_info_t chunk_info = 0;
-    e_chunk_strip_dir strip_dir;
-    uint8_t stripped_size;
     uint8_t start_idx;
-    uint8_t *ptr;
+    s_calldata_chunk *chunk;
+    s_calldata_chunk *tmp;
 
+    if ((chunk = app_mem_alloc(sizeof(*chunk))) == NULL) {
+        return false;
+    }
+    explicit_bzero(chunk, sizeof(*chunk));
     for (int i = 0; (i < CALLDATA_CHUNK_SIZE) && (calldata->chunk[i] == 0x00); ++i) {
         strip_left += 1;
     }
     for (int i = CALLDATA_CHUNK_SIZE - 1; (i >= 0) && (calldata->chunk[i] == 0x00); --i) {
         strip_right += 1;
     }
-
     if (strip_left >= strip_right) {
-        strip_dir = CHUNK_STRIP_LEFT;
-        stripped_size = CALLDATA_CHUNK_SIZE - strip_left;
+        chunk->dir = CHUNK_STRIP_LEFT;
+        chunk->size = CALLDATA_CHUNK_SIZE - strip_left;
         start_idx = strip_left;
     } else {
-        strip_dir = CHUNK_STRIP_RIGHT;
-        stripped_size = CALLDATA_CHUNK_SIZE - strip_right;
+        chunk->dir = CHUNK_STRIP_RIGHT;
+        chunk->size = CALLDATA_CHUNK_SIZE - strip_right;
         start_idx = 0;
     }
-    chunk_info |= strip_dir << CHUNK_INFO_DIR_OFFSET;
-    chunk_info |= stripped_size << CHUNK_INFO_SIZE_OFFSET;
-    if ((ptr = mem_legacy_alloc(sizeof(chunk_info) + stripped_size)) == NULL) {
+    if ((chunk->size > 0) && ((chunk->buf = app_mem_alloc(chunk->size)) == NULL)) {
+        app_mem_free(chunk);
         return false;
     }
+    memcpy(chunk->buf, calldata->chunk + start_idx, chunk->size);
+
     if (calldata->chunks == NULL) {
-        calldata->chunks = ptr;
+        calldata->chunks = chunk;
     } else {
-        if ((calldata->chunks + calldata->chunks_size) != ptr) {
-            // something was allocated in between two compressed chunks
-            return false;
-        }
+        for (tmp = calldata->chunks; tmp->next != NULL; tmp = tmp->next)
+            ;
+        tmp->next = chunk;
     }
-    calldata->chunks_size += sizeof(chunk_info) + stripped_size;
-    memcpy(ptr, &chunk_info, sizeof(chunk_info));
-    memcpy(ptr + sizeof(chunk_info), calldata->chunk + start_idx, stripped_size);
     return true;
 }
 
-static bool decompress_chunk(s_calldata *calldata, size_t offset) {
-    chunk_info_t chunk_info = calldata->chunks[offset];
-    const uint8_t *compressed_chunk = &calldata->chunks[offset + sizeof(chunk_info)];
+static bool decompress_chunk(const s_calldata_chunk *chunk, uint8_t *out) {
     size_t diff;
 
-    diff = CALLDATA_CHUNK_SIZE - CHUNK_INFO_SIZE(chunk_info);
-    if (CHUNK_INFO_DIR(chunk_info) == CHUNK_STRIP_LEFT) {
-        explicit_bzero(calldata->chunk, diff);
-        memcpy(&calldata->chunk[diff], compressed_chunk, CHUNK_INFO_SIZE(chunk_info));
+    diff = CALLDATA_CHUNK_SIZE - chunk->size;
+    if (chunk->dir == CHUNK_STRIP_LEFT) {
+        explicit_bzero(out, diff);
+        memcpy(&out[diff], chunk->buf, chunk->size);
     } else {
-        memcpy(calldata->chunk, compressed_chunk, CHUNK_INFO_SIZE(chunk_info));
-        explicit_bzero(&calldata->chunk[CHUNK_INFO_SIZE(chunk_info)], diff);
+        memcpy(out, chunk->buf, chunk->size);
+        explicit_bzero(&out[chunk->size], diff);
     }
     return true;
 }
@@ -159,21 +141,38 @@ bool calldata_append(const uint8_t *buffer, size_t size) {
         g_calldata->received_size += cpy_length;
     }
     if (g_calldata->received_size == g_calldata->expected_size) {
-        PRINTF("calldata reduced by ~%u%% with compression (%u -> %u bytes)\n",
-               100 - (100 * (CALLDATA_SELECTOR_SIZE + g_calldata->chunks_size) /
-                      g_calldata->received_size),
+#ifdef HAVE_PRINTF
+        // get allocated size
+        size_t compressed_size = sizeof(*g_calldata);
+        for (s_calldata_chunk *chunk = g_calldata->chunks; chunk != NULL; chunk = chunk->next) {
+            compressed_size += sizeof(*chunk);
+            compressed_size += chunk->size;
+        }
+
+        PRINTF("calldata size went from %u to %u bytes with compression\n",
                g_calldata->received_size,
-               CALLDATA_SELECTOR_SIZE + g_calldata->chunks_size);
+               compressed_size);
+#endif
     }
     return true;
 }
 
 void calldata_cleanup(void) {
+    s_calldata_chunk *chunk;
+    s_calldata_chunk *next;
+
     if (g_calldata != NULL) {
-        mem_legacy_dealloc(g_calldata->chunks_size);
-        mem_legacy_dealloc(sizeof(*g_calldata));
+        chunk = g_calldata->chunks;
+        while (chunk != NULL) {
+            next = chunk->next;
+            if (chunk->buf != NULL) {
+                app_mem_free(chunk->buf);
+            }
+            app_mem_free(chunk);
+            chunk = next;
+        }
+        app_mem_free(g_calldata);
         g_calldata = NULL;
-        mem_legacy_dealloc(g_calldata_alignment);
     }
 }
 
@@ -197,19 +196,16 @@ const uint8_t *calldata_get_selector(void) {
 }
 
 const uint8_t *calldata_get_chunk(int idx) {
-    size_t offset = 0;
-    size_t offset_after;
+    s_calldata_chunk *chunk;
 
     if (!has_valid_calldata(g_calldata) || (g_calldata->chunks == NULL)) {
         return NULL;
     }
+    chunk = g_calldata->chunks;
     for (int i = 0; i < idx; ++i) {
-        if (offset > g_calldata->chunks_size) return NULL;
-        offset += sizeof(chunk_info_t) + CHUNK_INFO_SIZE(g_calldata->chunks[offset]);
+        if (chunk->next == NULL) return NULL;
+        chunk = chunk->next;
     }
-    offset_after = offset + sizeof(chunk_info_t) + CHUNK_INFO_SIZE(g_calldata->chunks[offset]);
-    if ((offset_after > g_calldata->chunks_size) || !decompress_chunk(g_calldata, offset)) {
-        return NULL;
-    }
+    if (!decompress_chunk(chunk, g_calldata->chunk)) return NULL;
     return g_calldata->chunk;
 }

--- a/src_features/generic_tx_parser/calldata.c
+++ b/src_features/generic_tx_parser/calldata.c
@@ -47,8 +47,8 @@ bool calldata_init(size_t size) {
     if (g_calldata != NULL) {
         calldata_cleanup();
     }
-    g_calldata_alignment = mem_align(__alignof__(*g_calldata));
-    if ((g_calldata = mem_alloc(sizeof(*g_calldata))) == NULL) {
+    g_calldata_alignment = mem_legacy_align(__alignof__(*g_calldata));
+    if ((g_calldata = mem_legacy_alloc(sizeof(*g_calldata))) == NULL) {
         return false;
     }
     explicit_bzero(g_calldata, sizeof(*g_calldata));
@@ -83,7 +83,7 @@ static bool compress_chunk(s_calldata *calldata) {
     }
     chunk_info |= strip_dir << CHUNK_INFO_DIR_OFFSET;
     chunk_info |= stripped_size << CHUNK_INFO_SIZE_OFFSET;
-    if ((ptr = mem_alloc(sizeof(chunk_info) + stripped_size)) == NULL) {
+    if ((ptr = mem_legacy_alloc(sizeof(chunk_info) + stripped_size)) == NULL) {
         return false;
     }
     if (calldata->chunks == NULL) {
@@ -170,10 +170,10 @@ bool calldata_append(const uint8_t *buffer, size_t size) {
 
 void calldata_cleanup(void) {
     if (g_calldata != NULL) {
-        mem_dealloc(g_calldata->chunks_size);
-        mem_dealloc(sizeof(*g_calldata));
+        mem_legacy_dealloc(g_calldata->chunks_size);
+        mem_legacy_dealloc(sizeof(*g_calldata));
         g_calldata = NULL;
-        mem_dealloc(g_calldata_alignment);
+        mem_legacy_dealloc(g_calldata_alignment);
     }
 }
 

--- a/src_features/generic_tx_parser/cmd_field.c
+++ b/src_features/generic_tx_parser/cmd_field.c
@@ -1,14 +1,13 @@
 #include "cmd_field.h"
 #include "cx.h"
 #include "apdu_constants.h"
-#include "mem.h"
 #include "tlv.h"
 #include "tlv_apdu.h"
 #include "gtp_field.h"
 #include "cmd_tx_info.h"
 #include "gtp_tx_info.h"
 
-static bool handle_tlv_payload(const uint8_t *payload, uint16_t size, bool to_free) {
+static bool handle_tlv_payload(const uint8_t *payload, uint16_t size) {
     s_field field = {0};
     s_field_ctx ctx = {0};
     bool parsing_ret;
@@ -17,7 +16,6 @@ static bool handle_tlv_payload(const uint8_t *payload, uint16_t size, bool to_fr
     ctx.field = &field;
     parsing_ret = tlv_parse(payload, size, (f_tlv_data_handler) &handle_field_struct, &ctx);
     hashing_ret = cx_hash_no_throw(get_fields_hash_ctx(), 0, payload, size, NULL, 0) == CX_OK;
-    if (to_free) mem_legacy_dealloc(size);
     if (!parsing_ret || !hashing_ret) return false;
     if (!verify_field_struct(&ctx)) {
         PRINTF("Error: could not verify the field struct!\n");

--- a/src_features/generic_tx_parser/cmd_field.c
+++ b/src_features/generic_tx_parser/cmd_field.c
@@ -17,7 +17,7 @@ static bool handle_tlv_payload(const uint8_t *payload, uint16_t size, bool to_fr
     ctx.field = &field;
     parsing_ret = tlv_parse(payload, size, (f_tlv_data_handler) &handle_field_struct, &ctx);
     hashing_ret = cx_hash_no_throw(get_fields_hash_ctx(), 0, payload, size, NULL, 0) == CX_OK;
-    if (to_free) mem_dealloc(size);
+    if (to_free) mem_legacy_dealloc(size);
     if (!parsing_ret || !hashing_ret) return false;
     if (!verify_field_struct(&ctx)) {
         PRINTF("Error: could not verify the field struct!\n");

--- a/src_features/generic_tx_parser/cmd_tx_info.c
+++ b/src_features/generic_tx_parser/cmd_tx_info.c
@@ -3,7 +3,6 @@
 #include "cx.h"
 #include "apdu_constants.h"
 #include "mem.h"
-#include "mem_utils.h"
 #include "gtp_tx_info.h"
 #include "tlv.h"
 #include "tlv_apdu.h"
@@ -11,9 +10,8 @@
 #include "gtp_field_table.h"
 
 extern cx_sha3_t hash_ctx;
-static uint8_t g_tx_info_alignment;
 
-static bool handle_tlv_payload(const uint8_t *payload, uint16_t size, bool to_free) {
+static bool handle_tlv_payload(const uint8_t *payload, uint16_t size) {
     s_tx_info_ctx ctx = {0};
     bool parsing_ret;
 
@@ -21,7 +19,6 @@ static bool handle_tlv_payload(const uint8_t *payload, uint16_t size, bool to_fr
     explicit_bzero(ctx.tx_info, sizeof(*ctx.tx_info));
     cx_sha256_init((cx_sha256_t *) &ctx.struct_hash);
     parsing_ret = tlv_parse(payload, size, (f_tlv_data_handler) &handle_tx_info_struct, &ctx);
-    if (to_free) mem_legacy_dealloc(sizeof(size));
     if (!parsing_ret || !verify_tx_info_struct(&ctx)) {
         return false;
     }
@@ -46,8 +43,7 @@ uint16_t handle_tx_info(uint8_t p1, uint8_t p2, uint8_t lc, const uint8_t *paylo
             return APDU_RESPONSE_CONDITION_NOT_SATISFIED;
         }
 
-        g_tx_info_alignment = mem_legacy_align(__alignof__(*g_tx_info));
-        if ((g_tx_info = mem_legacy_alloc(sizeof(*g_tx_info))) == NULL) {
+        if ((g_tx_info = app_mem_alloc(sizeof(*g_tx_info))) == NULL) {
             return APDU_RESPONSE_INSUFFICIENT_MEMORY;
         }
     }
@@ -66,9 +62,8 @@ void gcs_cleanup(void) {
     ui_gcs_cleanup();
     field_table_cleanup();
     if (g_tx_info != NULL) {
-        mem_legacy_dealloc(sizeof(*g_tx_info));
+        app_mem_free(g_tx_info);
         g_tx_info = NULL;
-        mem_legacy_dealloc(g_tx_info_alignment);
     }
     calldata_cleanup();
 }

--- a/src_features/generic_tx_parser/cmd_tx_info.c
+++ b/src_features/generic_tx_parser/cmd_tx_info.c
@@ -21,7 +21,7 @@ static bool handle_tlv_payload(const uint8_t *payload, uint16_t size, bool to_fr
     explicit_bzero(ctx.tx_info, sizeof(*ctx.tx_info));
     cx_sha256_init((cx_sha256_t *) &ctx.struct_hash);
     parsing_ret = tlv_parse(payload, size, (f_tlv_data_handler) &handle_tx_info_struct, &ctx);
-    if (to_free) mem_dealloc(sizeof(size));
+    if (to_free) mem_legacy_dealloc(sizeof(size));
     if (!parsing_ret || !verify_tx_info_struct(&ctx)) {
         return false;
     }
@@ -46,8 +46,8 @@ uint16_t handle_tx_info(uint8_t p1, uint8_t p2, uint8_t lc, const uint8_t *paylo
             return APDU_RESPONSE_CONDITION_NOT_SATISFIED;
         }
 
-        g_tx_info_alignment = mem_align(__alignof__(*g_tx_info));
-        if ((g_tx_info = mem_alloc(sizeof(*g_tx_info))) == NULL) {
+        g_tx_info_alignment = mem_legacy_align(__alignof__(*g_tx_info));
+        if ((g_tx_info = mem_legacy_alloc(sizeof(*g_tx_info))) == NULL) {
             return APDU_RESPONSE_INSUFFICIENT_MEMORY;
         }
     }
@@ -66,9 +66,9 @@ void gcs_cleanup(void) {
     ui_gcs_cleanup();
     field_table_cleanup();
     if (g_tx_info != NULL) {
-        mem_dealloc(sizeof(*g_tx_info));
+        mem_legacy_dealloc(sizeof(*g_tx_info));
         g_tx_info = NULL;
-        mem_dealloc(g_tx_info_alignment);
+        mem_legacy_dealloc(g_tx_info_alignment);
     }
     calldata_cleanup();
 }

--- a/src_features/generic_tx_parser/gtp_data_path.c
+++ b/src_features/generic_tx_parser/gtp_data_path.c
@@ -167,7 +167,7 @@ static bool path_leaf(const s_leaf_args *leaf,
     }
     collection->value[collection->size].length = collection->value[collection->size].size;
     collection->value[collection->size].offset = 0;
-    if ((leaf_buf = mem_legacy_rev_alloc(collection->value[collection->size].length)) == NULL) {
+    if ((leaf_buf = app_mem_alloc(collection->value[collection->size].length)) == NULL) {
         return false;
     }
     for (int chunk_idx = 0;
@@ -324,6 +324,6 @@ bool data_path_get(const s_data_path *data_path, s_parsed_value_collection *coll
 
 void data_path_cleanup(const s_parsed_value_collection *collection) {
     for (int i = 0; i < collection->size; ++i) {
-        mem_legacy_rev_dealloc(collection->value[i].size);
+        app_mem_free((void *) collection->value[i].ptr);
     }
 }

--- a/src_features/generic_tx_parser/gtp_data_path.c
+++ b/src_features/generic_tx_parser/gtp_data_path.c
@@ -167,7 +167,7 @@ static bool path_leaf(const s_leaf_args *leaf,
     }
     collection->value[collection->size].length = collection->value[collection->size].size;
     collection->value[collection->size].offset = 0;
-    if ((leaf_buf = mem_rev_alloc(collection->value[collection->size].length)) == NULL) {
+    if ((leaf_buf = mem_legacy_rev_alloc(collection->value[collection->size].length)) == NULL) {
         return false;
     }
     for (int chunk_idx = 0;
@@ -324,6 +324,6 @@ bool data_path_get(const s_data_path *data_path, s_parsed_value_collection *coll
 
 void data_path_cleanup(const s_parsed_value_collection *collection) {
     for (int i = 0; i < collection->size; ++i) {
-        mem_rev_dealloc(collection->value[i].size);
+        mem_legacy_rev_dealloc(collection->value[i].size);
     }
 }

--- a/src_features/generic_tx_parser/gtp_field_table.c
+++ b/src_features/generic_tx_parser/gtp_field_table.c
@@ -51,7 +51,7 @@ void field_table_cleanup(void) {
         for (size_t i = 0; i < g_table.size; ++i) {
             ptr = get_next_table_entry(ptr, NULL);
         }
-        mem_dealloc(ptr - g_table.start);
+        mem_legacy_dealloc(ptr - g_table.start);
         g_table.start = NULL;
     }
 }
@@ -69,8 +69,8 @@ bool add_to_field_table(e_param_type type, const char *key, const char *value) {
     key_len = strlen(key) + 1;
     value_len = strlen(value) + 1;
     PRINTF(">>> \"%s\": \"%s\"\n", key, value);
-    if ((ptr = mem_alloc(sizeof(type) + sizeof(uint8_t) + sizeof(uint16_t) + key_len +
-                         value_len)) == NULL) {
+    if ((ptr = mem_legacy_alloc(sizeof(type) + sizeof(uint8_t) + sizeof(uint16_t) + key_len +
+                                value_len)) == NULL) {
         return false;
     }
     if ((g_table.start == NULL) && (g_table.size == 0)) {

--- a/src_features/generic_tx_parser/gtp_field_table.c
+++ b/src_features/generic_tx_parser/gtp_field_table.c
@@ -3,10 +3,13 @@
 #include "gtp_field_table.h"
 #include "mem.h"
 
-// type (1) | key_length (1) | value_length (2) | key ($key_length) | value ($value_length)
+typedef struct field_table_node {
+    s_field_table_entry field;
+    struct field_table_node *next;
+} s_field_table_node;
 
 typedef struct {
-    const uint8_t *start;
+    s_field_table_node *nodes;
     size_t size;
 } s_field_table;
 
@@ -16,75 +19,62 @@ void field_table_init(void) {
     explicit_bzero(&g_table, sizeof(g_table));
 }
 
-static const uint8_t *get_next_table_entry(const uint8_t *ptr, s_field_table_entry *entry) {
-    uint8_t key_len;
-    uint16_t value_len;
-
-    if (ptr == NULL) {
-        return NULL;
-    }
-    if (entry != NULL) {
-        memcpy(&entry->type, ptr, sizeof(entry->type));
-    }
-    ptr += sizeof(entry->type);
-    memcpy(&key_len, ptr, sizeof(key_len));
-    ptr += sizeof(key_len);
-    memcpy(&value_len, ptr, sizeof(value_len));
-    ptr += sizeof(value_len);
-    if (entry != NULL) {
-        entry->key = (char *) ptr;
-    }
-    ptr += key_len;
-    if (entry != NULL) {
-        entry->value = (char *) ptr;
-    }
-    ptr += value_len;
-    return ptr;
-}
-
 // after this function, field_table_init() will have to be called before using any other field_table
 // function
 void field_table_cleanup(void) {
-    const uint8_t *ptr = g_table.start;
+    s_field_table_node *node;
+    s_field_table_node *next;
 
-    if (ptr != NULL) {
-        for (size_t i = 0; i < g_table.size; ++i) {
-            ptr = get_next_table_entry(ptr, NULL);
-        }
-        mem_legacy_dealloc(ptr - g_table.start);
-        g_table.start = NULL;
+    node = g_table.nodes;
+    while (node != NULL) {
+        next = node->next;
+        if (node->field.key != NULL) app_mem_free(node->field.key);
+        if (node->field.value != NULL) app_mem_free(node->field.value);
+        app_mem_free(node);
+        node = next;
     }
+    g_table.nodes = NULL;
 }
 
 bool add_to_field_table(e_param_type type, const char *key, const char *value) {
-    int offset = 0;
-    uint8_t *ptr;
     uint8_t key_len;
     uint16_t value_len;
+    s_field_table_node *node;
+    s_field_table_node *tmp;
 
     if ((key == NULL) || (value == NULL)) {
         PRINTF("Error: NULL key/value!\n");
         return false;
     }
-    key_len = strlen(key) + 1;
-    value_len = strlen(value) + 1;
-    PRINTF(">>> \"%s\": \"%s\"\n", key, value);
-    if ((ptr = mem_legacy_alloc(sizeof(type) + sizeof(uint8_t) + sizeof(uint16_t) + key_len +
-                                value_len)) == NULL) {
+    if ((node = app_mem_alloc(sizeof(*node))) == NULL) {
         return false;
     }
-    if ((g_table.start == NULL) && (g_table.size == 0)) {
-        g_table.start = ptr;
+    key_len = strlen(key) + 1;
+    value_len = strlen(value) + 1;
+    if ((node->field.key = app_mem_alloc(key_len)) == NULL) {
+        app_mem_free(node);
+        return false;
     }
-    memcpy(&ptr[offset], &type, sizeof(type));
-    offset += sizeof(type);
-    memcpy(&ptr[offset], &key_len, sizeof(key_len));
-    offset += sizeof(key_len);
-    memcpy(&ptr[offset], &value_len, sizeof(value_len));
-    offset += sizeof(value_len);
-    memcpy(&ptr[offset], key, key_len);
-    offset += key_len;
-    memcpy(&ptr[offset], value, value_len);
+    if ((node->field.value = app_mem_alloc(value_len)) == NULL) {
+        app_mem_free(node->field.key);
+        app_mem_free(node);
+        return false;
+    }
+    PRINTF(">>> \"%s\": \"%s\"\n", key, value);
+
+    node->field.type = type;
+    memcpy(node->field.key, key, key_len);
+    memcpy(node->field.value, value, value_len);
+    node->next = NULL;
+
+    if (g_table.nodes == NULL) {
+        g_table.nodes = node;
+    } else {
+        for (tmp = g_table.nodes; tmp->next != NULL; tmp = tmp->next)
+            ;
+        tmp->next = node;
+    }
+
     g_table.size += 1;
     return true;
 }
@@ -93,17 +83,15 @@ size_t field_table_size(void) {
     return g_table.size;
 }
 
-bool get_from_field_table(int index, s_field_table_entry *entry) {
-    const uint8_t *ptr = g_table.start;
+const s_field_table_entry *get_from_field_table(int index) {
+    const s_field_table_node *node = g_table.nodes;
 
     if ((size_t) index >= g_table.size) {
-        return false;
+        return NULL;
     }
-    if (ptr == NULL) {
-        return false;
+    for (int i = 0; i < index; ++i) {
+        if (node == NULL) return NULL;
+        node = node->next;
     }
-    for (int i = 0; i <= index; ++i) {
-        ptr = get_next_table_entry(ptr, entry);
-    }
-    return true;
+    return &node->field;
 }

--- a/src_features/generic_tx_parser/gtp_field_table.h
+++ b/src_features/generic_tx_parser/gtp_field_table.h
@@ -6,12 +6,12 @@
 
 typedef struct {
     e_param_type type;
-    const char *key;
-    const char *value;
+    char *key;
+    char *value;
 } s_field_table_entry;
 
 void field_table_init(void);
 void field_table_cleanup(void);
 bool add_to_field_table(e_param_type type, const char *key, const char *value);
 size_t field_table_size(void);
-bool get_from_field_table(int index, s_field_table_entry *entry);
+const s_field_table_entry *get_from_field_table(int index);

--- a/src_features/provide_enum_value/cmd_enum_value.c
+++ b/src_features/provide_enum_value/cmd_enum_value.c
@@ -11,7 +11,7 @@ static bool handle_tlv_payload(const uint8_t *payload, uint16_t size, bool to_fr
 
     cx_sha256_init(&ctx.struct_hash);
     parsing_ret = tlv_parse(payload, size, (f_tlv_data_handler) &handle_enum_value_struct, &ctx);
-    if (to_free) mem_dealloc(sizeof(size));
+    if (to_free) mem_legacy_dealloc(sizeof(size));
     if (!parsing_ret) return false;
     if (!verify_enum_value_struct(&ctx)) {
         return false;

--- a/src_features/provide_enum_value/cmd_enum_value.c
+++ b/src_features/provide_enum_value/cmd_enum_value.c
@@ -1,17 +1,15 @@
 #include "cmd_enum_value.h"
 #include "apdu_constants.h"
-#include "mem.h"
 #include "enum_value.h"
 #include "tlv_apdu.h"
 #include "tlv.h"
 
-static bool handle_tlv_payload(const uint8_t *payload, uint16_t size, bool to_free) {
+static bool handle_tlv_payload(const uint8_t *payload, uint16_t size) {
     bool parsing_ret;
     s_enum_value_ctx ctx = {0};
 
     cx_sha256_init(&ctx.struct_hash);
     parsing_ret = tlv_parse(payload, size, (f_tlv_data_handler) &handle_enum_value_struct, &ctx);
-    if (to_free) mem_legacy_dealloc(sizeof(size));
     if (!parsing_ret) return false;
     if (!verify_enum_value_struct(&ctx)) {
         return false;

--- a/src_features/provide_network_info/cmd_network_info.c
+++ b/src_features/provide_network_info/cmd_network_info.c
@@ -4,7 +4,6 @@
 #include "network_info.h"
 #include "write.h"
 #include "tlv_apdu.h"
-#include "mem.h"
 
 #define P2_NETWORK_CONFIG 0x00
 #define P2_NETWORK_ICON   0x01
@@ -254,14 +253,13 @@ static uint16_t handle_get_config(void) {
     return tx;
 }
 
-static bool handle_tlv_payload(const uint8_t *payload, uint16_t size, bool to_free) {
+static bool handle_tlv_payload(const uint8_t *payload, uint16_t size) {
     bool parsing_ret;
     s_network_info_ctx ctx = {0};
 
     // Initialize the hash context
     cx_sha256_init(&ctx.hash_ctx);
     parsing_ret = tlv_parse(payload, size, (f_tlv_data_handler) &handle_network_info_struct, &ctx);
-    if (to_free) mem_legacy_dealloc(sizeof(size));
     if (!parsing_ret || !verify_network_info_struct(&ctx)) {
         return false;
     }

--- a/src_features/provide_network_info/cmd_network_info.c
+++ b/src_features/provide_network_info/cmd_network_info.c
@@ -261,7 +261,7 @@ static bool handle_tlv_payload(const uint8_t *payload, uint16_t size, bool to_fr
     // Initialize the hash context
     cx_sha256_init(&ctx.hash_ctx);
     parsing_ret = tlv_parse(payload, size, (f_tlv_data_handler) &handle_network_info_struct, &ctx);
-    if (to_free) mem_dealloc(sizeof(size));
+    if (to_free) mem_legacy_dealloc(sizeof(size));
     if (!parsing_ret || !verify_network_info_struct(&ctx)) {
         return false;
     }

--- a/src_features/provide_proxy_info/cmd_proxy_info.c
+++ b/src_features/provide_proxy_info/cmd_proxy_info.c
@@ -1,16 +1,14 @@
 #include "cmd_proxy_info.h"
 #include "proxy_info.h"
 #include "tlv_apdu.h"
-#include "mem.h"
 #include "apdu_constants.h"
 
-static bool handle_tlv_payload(const uint8_t *payload, uint16_t size, bool to_free) {
+static bool handle_tlv_payload(const uint8_t *payload, uint16_t size) {
     s_proxy_info_ctx ctx = {0};
     bool parsing_ret;
 
     cx_sha256_init(&ctx.struct_hash);
     parsing_ret = tlv_parse(payload, size, (f_tlv_data_handler) &handle_proxy_info_struct, &ctx);
-    if (to_free) mem_legacy_dealloc(sizeof(size));
     if (!parsing_ret || !verify_proxy_info_struct(&ctx)) {
         return false;
     }

--- a/src_features/provide_proxy_info/cmd_proxy_info.c
+++ b/src_features/provide_proxy_info/cmd_proxy_info.c
@@ -10,7 +10,7 @@ static bool handle_tlv_payload(const uint8_t *payload, uint16_t size, bool to_fr
 
     cx_sha256_init(&ctx.struct_hash);
     parsing_ret = tlv_parse(payload, size, (f_tlv_data_handler) &handle_proxy_info_struct, &ctx);
-    if (to_free) mem_dealloc(sizeof(size));
+    if (to_free) mem_legacy_dealloc(sizeof(size));
     if (!parsing_ret || !verify_proxy_info_struct(&ctx)) {
         return false;
     }

--- a/src_features/provide_trusted_name/cmd_trusted_name.c
+++ b/src_features/provide_trusted_name/cmd_trusted_name.c
@@ -1,19 +1,17 @@
 #include <stdbool.h>
 #include "cmd_trusted_name.h"
 #include "trusted_name.h"
-#include "mem.h"
 #include "challenge.h"
 #include "tlv_apdu.h"
 #include "apdu_constants.h"
 
-static bool handle_tlv_payload(const uint8_t *payload, uint16_t size, bool to_free) {
+static bool handle_tlv_payload(const uint8_t *payload, uint16_t size) {
     s_trusted_name_ctx ctx = {0};
     bool parsing_ret;
 
     ctx.trusted_name.name = g_trusted_name;
     cx_sha256_init(&ctx.hash_ctx);
     parsing_ret = tlv_parse(payload, size, (f_tlv_data_handler) &handle_trusted_name_struct, &ctx);
-    if (to_free) mem_legacy_dealloc(size);
     if (!parsing_ret || !verify_trusted_name_struct(&ctx)) {
         roll_challenge();  // prevent brute-force guesses
         return false;

--- a/src_features/provide_trusted_name/cmd_trusted_name.c
+++ b/src_features/provide_trusted_name/cmd_trusted_name.c
@@ -13,7 +13,7 @@ static bool handle_tlv_payload(const uint8_t *payload, uint16_t size, bool to_fr
     ctx.trusted_name.name = g_trusted_name;
     cx_sha256_init(&ctx.hash_ctx);
     parsing_ret = tlv_parse(payload, size, (f_tlv_data_handler) &handle_trusted_name_struct, &ctx);
-    if (to_free) mem_dealloc(size);
+    if (to_free) mem_legacy_dealloc(size);
     if (!parsing_ret || !verify_trusted_name_struct(&ctx)) {
         roll_challenge();  // prevent brute-force guesses
         return false;

--- a/src_features/provide_tx_simulation/cmd_get_tx_simulation.c
+++ b/src_features/provide_tx_simulation/cmd_get_tx_simulation.c
@@ -7,7 +7,6 @@
 #include "getPublicKey.h"
 #include "tlv.h"
 #include "tlv_apdu.h"
-#include "mem.h"
 #include "utils.h"
 #include "nbgl_use_case.h"
 #include "os_pki.h"
@@ -467,10 +466,9 @@ static bool handle_tx_simu_tlv(const s_tlv_data *data, s_tx_simu_ctx *context) {
  *
  * @param[in] payload buffer received
  * @param[in] size of the buffer
- * @param[in] to_free if the payload needs to be freed
  * @return whether the TLV payload was handled successfully or not
  */
-static bool handle_tlv_payload(const uint8_t *payload, uint16_t size, bool to_free) {
+static bool handle_tlv_payload(const uint8_t *payload, uint16_t size) {
     bool parsing_ret;
     s_tx_simu_ctx ctx = {0};
 
@@ -481,7 +479,6 @@ static bool handle_tlv_payload(const uint8_t *payload, uint16_t size, bool to_fr
     cx_sha256_init(&ctx.hash_ctx);
 
     parsing_ret = tlv_parse(payload, size, (f_tlv_data_handler) &handle_tx_simu_tlv, &ctx);
-    if (to_free) mem_legacy_dealloc(size);
     if (!parsing_ret || !verify_fields(&ctx) || !verify_signature(&ctx)) {
         explicit_bzero(&TX_SIMULATION, sizeof(TX_SIMULATION));
         explicit_bzero(&ctx, sizeof(s_tx_simu_ctx));

--- a/src_features/provide_tx_simulation/cmd_get_tx_simulation.c
+++ b/src_features/provide_tx_simulation/cmd_get_tx_simulation.c
@@ -481,7 +481,7 @@ static bool handle_tlv_payload(const uint8_t *payload, uint16_t size, bool to_fr
     cx_sha256_init(&ctx.hash_ctx);
 
     parsing_ret = tlv_parse(payload, size, (f_tlv_data_handler) &handle_tx_simu_tlv, &ctx);
-    if (to_free) mem_dealloc(size);
+    if (to_free) mem_legacy_dealloc(size);
     if (!parsing_ret || !verify_fields(&ctx) || !verify_signature(&ctx)) {
         explicit_bzero(&TX_SIMULATION, sizeof(TX_SIMULATION));
         explicit_bzero(&ctx, sizeof(s_tx_simu_ctx));

--- a/src_features/signAuthorizationEIP7702/commands_7702.c
+++ b/src_features/signAuthorizationEIP7702/commands_7702.c
@@ -5,7 +5,6 @@
 #include "network.h"
 #include "crypto_helpers.h"
 #include "write.h"
-#include "mem.h"
 #include "commands_7702.h"
 #include "shared_7702.h"
 #include "rlp_encode.h"
@@ -55,7 +54,7 @@ uint16_t hashRLP64(uint64_t data, uint8_t *rlpTmp, uint8_t rlpTmpLength) {
     return hashRLP(tmp + sizeof(tmp) - encodingLength, encodingLength, rlpTmp, rlpTmpLength);
 }
 
-static bool handleAuth7702TLV(const uint8_t *payload, uint16_t size, bool to_free) {
+static bool handleAuth7702TLV(const uint8_t *payload, uint16_t size) {
     s_auth_7702_ctx auth_7702_ctx = {0};
     s_auth_7702 *auth7702 = &auth_7702_ctx.auth_7702;
     bool parsing_ret;
@@ -70,7 +69,6 @@ static bool handleAuth7702TLV(const uint8_t *payload, uint16_t size, bool to_fre
 
     parsing_ret =
         tlv_parse(payload, size, (f_tlv_data_handler) handle_auth_7702_struct, &auth_7702_ctx);
-    if (to_free) mem_legacy_dealloc(size);
     if (!parsing_ret || !verify_auth_7702_struct(&auth_7702_ctx)) {
         g_7702_sw = APDU_RESPONSE_INVALID_DATA;
         return false;

--- a/src_features/signAuthorizationEIP7702/commands_7702.c
+++ b/src_features/signAuthorizationEIP7702/commands_7702.c
@@ -70,7 +70,7 @@ static bool handleAuth7702TLV(const uint8_t *payload, uint16_t size, bool to_fre
 
     parsing_ret =
         tlv_parse(payload, size, (f_tlv_data_handler) handle_auth_7702_struct, &auth_7702_ctx);
-    if (to_free) mem_dealloc(size);
+    if (to_free) mem_legacy_dealloc(size);
     if (!parsing_ret || !verify_auth_7702_struct(&auth_7702_ctx)) {
         g_7702_sw = APDU_RESPONSE_INVALID_DATA;
         return false;

--- a/src_features/signMessageEIP712/context_712.c
+++ b/src_features/signMessageEIP712/context_712.c
@@ -20,7 +20,7 @@ s_eip712_context *eip712_context = NULL;
  */
 bool eip712_context_init(void) {
     // init global variables
-    mem_init();
+    mem_legacy_init();
 
     if ((eip712_context = MEM_ALLOC_AND_ALIGN_TYPE(*eip712_context)) == NULL) {
         apdu_response_code = APDU_RESPONSE_INSUFFICIENT_MEMORY;
@@ -66,7 +66,7 @@ void eip712_context_deinit(void) {
     path_deinit();
     field_hash_deinit();
     ui_712_deinit();
-    mem_reset();
+    mem_legacy_reset();
     eip712_context = NULL;
     reset_app_context();
 }

--- a/src_features/signMessageEIP712/context_712.c
+++ b/src_features/signMessageEIP712/context_712.c
@@ -19,9 +19,10 @@ s_eip712_context *eip712_context = NULL;
  * @return a boolean indicating if the initialization was successful or not
  */
 bool eip712_context_init(void) {
-    // init global variables
+    // switch to legacy allocator
     mem_legacy_init();
 
+    // init global variables
     if ((eip712_context = MEM_ALLOC_AND_ALIGN_TYPE(*eip712_context)) == NULL) {
         apdu_response_code = APDU_RESPONSE_INSUFFICIENT_MEMORY;
         return false;
@@ -66,7 +67,8 @@ void eip712_context_deinit(void) {
     path_deinit();
     field_hash_deinit();
     ui_712_deinit();
-    mem_legacy_reset();
+    // switch back to SDK allocator
+    app_mem_init();
     eip712_context = NULL;
     reset_app_context();
 }

--- a/src_features/signMessageEIP712/encode_field.c
+++ b/src_features/signMessageEIP712/encode_field.c
@@ -25,7 +25,7 @@ static void *field_encode(const uint8_t *const value,
         apdu_response_code = APDU_RESPONSE_INVALID_DATA;
         return NULL;
     }
-    if ((padded_value = mem_alloc(EIP_712_ENCODED_FIELD_LENGTH)) != NULL) {
+    if ((padded_value = mem_legacy_alloc(EIP_712_ENCODED_FIELD_LENGTH)) != NULL) {
         switch (ptype) {
             case MSB:
                 memset(padded_value, pval, EIP_712_ENCODED_FIELD_LENGTH - length);

--- a/src_features/signMessageEIP712/field_hash.c
+++ b/src_features/signMessageEIP712/field_hash.c
@@ -116,7 +116,7 @@ static uint8_t *field_hash_finalize_dynamic(void) {
     uint8_t *value;
     cx_err_t error = CX_INTERNAL_ERROR;
 
-    if ((value = mem_alloc(KECCAK256_HASH_BYTESIZE)) == NULL) {
+    if ((value = mem_legacy_alloc(KECCAK256_HASH_BYTESIZE)) == NULL) {
         apdu_response_code = APDU_RESPONSE_INSUFFICIENT_MEMORY;
         return NULL;
     }
@@ -153,7 +153,7 @@ static void field_hash_feed_parent(e_type field_type, const uint8_t *const hash)
     // continue the progressive hash on it
     hash_nbytes(hash, len, (cx_hash_t *) hash_ctx);
     // deallocate it
-    mem_dealloc(len);
+    mem_legacy_dealloc(len);
 }
 
 /**

--- a/src_features/signMessageEIP712/format_hash_field_type.c
+++ b/src_features/signMessageEIP712/format_hash_field_type.c
@@ -31,13 +31,13 @@ static bool format_hash_field_type_size(const void *const field_ptr, cx_hash_t *
             apdu_response_code = APDU_RESPONSE_INVALID_DATA;
             return false;
     }
-    uint_str_ptr = mem_alloc_and_format_uint(field_size, &uint_str_len);
+    uint_str_ptr = mem_legacy_alloc_and_format_uint(field_size, &uint_str_len);
     if (uint_str_ptr == NULL) {
         apdu_response_code = APDU_RESPONSE_INSUFFICIENT_MEMORY;
         return false;
     }
     hash_nbytes((uint8_t *) uint_str_ptr, uint_str_len, hash_ctx);
-    mem_dealloc(uint_str_len);
+    mem_legacy_dealloc(uint_str_len);
     return true;
 }
 
@@ -63,12 +63,13 @@ static bool format_hash_field_type_array_levels(const void *const field_ptr, cx_
             case ARRAY_DYNAMIC:
                 break;
             case ARRAY_FIXED_SIZE:
-                if ((uint_str_ptr = mem_alloc_and_format_uint(array_size, &uint_str_len)) == NULL) {
+                if ((uint_str_ptr = mem_legacy_alloc_and_format_uint(array_size, &uint_str_len)) ==
+                    NULL) {
                     apdu_response_code = APDU_RESPONSE_INSUFFICIENT_MEMORY;
                     return false;
                 }
                 hash_nbytes((uint8_t *) uint_str_ptr, uint_str_len, hash_ctx);
-                mem_dealloc(uint_str_len);
+                mem_legacy_dealloc(uint_str_len);
                 break;
             default:
                 // should not be in here :^)

--- a/src_features/signMessageEIP712/path.c
+++ b/src_features/signMessageEIP712/path.c
@@ -140,7 +140,7 @@ static bool path_depth_list_push(void) {
  * @return pointer to the hashing context
  */
 static cx_sha3_t *get_last_hash_ctx(void) {
-    return ((cx_sha3_t *) mem_alloc(0)) - 1;
+    return ((cx_sha3_t *) mem_legacy_alloc(0)) - 1;
 }
 
 /**
@@ -159,7 +159,7 @@ static bool finalize_hash_depth(uint8_t *hash) {
     // finalize hash
     CX_CHECK(
         cx_hash_no_throw((cx_hash_t *) hash_ctx, CX_LAST, NULL, 0, hash, KECCAK256_HASH_BYTESIZE));
-    mem_dealloc(sizeof(*hash_ctx));  // remove hash context
+    mem_legacy_dealloc(sizeof(*hash_ctx));  // remove hash context
     return hashed_bytes > 0;
 end:
     return false;

--- a/src_features/signMessageEIP712/sol_typenames.c
+++ b/src_features/signMessageEIP712/sol_typenames.c
@@ -31,7 +31,7 @@ static bool find_enum_matches(const uint8_t enum_to_idx[TYPES_COUNT - 1][IDX_COU
             {
                 *enum_match |= TYPENAME_MORE_TYPE;
             }
-            if ((enum_match = mem_alloc(sizeof(uint8_t))) == NULL) {
+            if ((enum_match = mem_legacy_alloc(sizeof(uint8_t))) == NULL) {
                 apdu_response_code = APDU_RESPONSE_INSUFFICIENT_MEMORY;
                 return false;
             }
@@ -66,7 +66,7 @@ bool sol_typenames_init(void) {
     uint8_t *typename_len_ptr;
     char *typename_ptr;
 
-    if ((sol_typenames = mem_alloc(sizeof(uint8_t))) == NULL) {
+    if ((sol_typenames = mem_legacy_alloc(sizeof(uint8_t))) == NULL) {
         return false;
     }
     *(sol_typenames) = 0;
@@ -74,14 +74,14 @@ bool sol_typenames_init(void) {
     for (uint8_t t_idx = 0; t_idx < ARRAY_SIZE(typenames); ++t_idx) {
         // if at least one match was found
         if (find_enum_matches(enum_to_idx, t_idx)) {
-            if ((typename_len_ptr = mem_alloc(sizeof(uint8_t))) == NULL) {
+            if ((typename_len_ptr = mem_legacy_alloc(sizeof(uint8_t))) == NULL) {
                 apdu_response_code = APDU_RESPONSE_INSUFFICIENT_MEMORY;
                 return false;
             }
             // get pointer to the allocated space just above
             *typename_len_ptr = strlen(PIC(typenames[t_idx]));
 
-            if ((typename_ptr = mem_alloc(sizeof(char) * *typename_len_ptr)) == NULL) {
+            if ((typename_ptr = mem_legacy_alloc(sizeof(char) * *typename_len_ptr)) == NULL) {
                 apdu_response_code = APDU_RESPONSE_INSUFFICIENT_MEMORY;
                 return false;
             }

--- a/src_features/signMessageEIP712/type_hash.c
+++ b/src_features/signMessageEIP712/type_hash.c
@@ -169,7 +169,7 @@ bool type_hash(const char *const struct_name, const uint8_t struct_name_length, 
     const void *struct_ptr;
     uint8_t deps_count = 0;
     const void **deps;
-    void *mem_loc_bak = mem_alloc(0);
+    void *mem_loc_bak = mem_legacy_alloc(0);
     cx_err_t error = CX_INTERNAL_ERROR;
 
     if ((struct_ptr = get_structn(struct_name, struct_name_length)) == NULL) {
@@ -194,7 +194,7 @@ bool type_hash(const char *const struct_name, const uint8_t struct_name_length, 
         }
         deps += 1;
     }
-    mem_dealloc(mem_alloc(0) - mem_loc_bak);
+    mem_legacy_dealloc(mem_legacy_alloc(0) - mem_loc_bak);
 
     // copy hash into memory
     CX_CHECK(cx_hash_no_throw((cx_hash_t *) &global_sha3,

--- a/src_features/signMessageEIP712/typed_data.c
+++ b/src_features/signMessageEIP712/typed_data.c
@@ -19,7 +19,7 @@ bool typed_data_init(void) {
             return false;
         }
         // set types pointer
-        if ((typed_data->structs_array = mem_alloc(sizeof(uint8_t))) == NULL) {
+        if ((typed_data->structs_array = mem_legacy_alloc(sizeof(uint8_t))) == NULL) {
             apdu_response_code = APDU_RESPONSE_INSUFFICIENT_MEMORY;
             return false;
         }
@@ -458,21 +458,21 @@ bool set_struct_name(uint8_t length, const uint8_t *const name) {
     }
 
     // copy length
-    if ((length_ptr = mem_alloc(sizeof(uint8_t))) == NULL) {
+    if ((length_ptr = mem_legacy_alloc(sizeof(uint8_t))) == NULL) {
         apdu_response_code = APDU_RESPONSE_INSUFFICIENT_MEMORY;
         return false;
     }
     *length_ptr = length;
 
     // copy name
-    if ((name_ptr = mem_alloc(sizeof(char) * length)) == NULL) {
+    if ((name_ptr = mem_legacy_alloc(sizeof(char) * length)) == NULL) {
         apdu_response_code = APDU_RESPONSE_INSUFFICIENT_MEMORY;
         return false;
     }
     memmove(name_ptr, name, length);
 
     // initialize number of fields
-    if ((typed_data->current_struct_fields_array = mem_alloc(sizeof(uint8_t))) == NULL) {
+    if ((typed_data->current_struct_fields_array = mem_legacy_alloc(sizeof(uint8_t))) == NULL) {
         apdu_response_code = APDU_RESPONSE_INSUFFICIENT_MEMORY;
         return false;
     }
@@ -500,7 +500,7 @@ static const typedesc_t *set_struct_field_typedesc(const uint8_t *const data,
         apdu_response_code = APDU_RESPONSE_INVALID_DATA;
         return NULL;
     }
-    if ((typedesc_ptr = mem_alloc(sizeof(uint8_t))) == NULL) {
+    if ((typedesc_ptr = mem_legacy_alloc(sizeof(uint8_t))) == NULL) {
         apdu_response_code = APDU_RESPONSE_INSUFFICIENT_MEMORY;
         return NULL;
     }
@@ -527,7 +527,7 @@ static bool set_struct_field_custom_typename(const uint8_t *const data,
         apdu_response_code = APDU_RESPONSE_INVALID_DATA;
         return false;
     }
-    if ((typename_len_ptr = mem_alloc(sizeof(uint8_t))) == NULL) {
+    if ((typename_len_ptr = mem_legacy_alloc(sizeof(uint8_t))) == NULL) {
         apdu_response_code = APDU_RESPONSE_INSUFFICIENT_MEMORY;
         return false;
     }
@@ -539,7 +539,7 @@ static bool set_struct_field_custom_typename(const uint8_t *const data,
         apdu_response_code = APDU_RESPONSE_INVALID_DATA;
         return false;
     }
-    if ((typename = mem_alloc(sizeof(char) * *typename_len_ptr)) == NULL) {
+    if ((typename = mem_legacy_alloc(sizeof(char) * *typename_len_ptr)) == NULL) {
         apdu_response_code = APDU_RESPONSE_INSUFFICIENT_MEMORY;
         return false;
     }
@@ -565,7 +565,7 @@ static bool set_struct_field_array(const uint8_t *const data, uint8_t *data_idx,
         apdu_response_code = APDU_RESPONSE_INVALID_DATA;
         return false;
     }
-    if ((array_levels_count = mem_alloc(sizeof(uint8_t))) == NULL) {
+    if ((array_levels_count = mem_legacy_alloc(sizeof(uint8_t))) == NULL) {
         apdu_response_code = APDU_RESPONSE_INSUFFICIENT_MEMORY;
         return false;
     }
@@ -576,7 +576,7 @@ static bool set_struct_field_array(const uint8_t *const data, uint8_t *data_idx,
             apdu_response_code = APDU_RESPONSE_INVALID_DATA;
             return false;
         }
-        if ((array_level = mem_alloc(sizeof(*array_level))) == NULL) {
+        if ((array_level = mem_legacy_alloc(sizeof(*array_level))) == NULL) {
             apdu_response_code = APDU_RESPONSE_INSUFFICIENT_MEMORY;
             return false;
         }
@@ -594,7 +594,7 @@ static bool set_struct_field_array(const uint8_t *const data, uint8_t *data_idx,
                     apdu_response_code = APDU_RESPONSE_INVALID_DATA;
                     return false;
                 }
-                if ((array_level_size = mem_alloc(sizeof(uint8_t))) == NULL) {
+                if ((array_level_size = mem_legacy_alloc(sizeof(uint8_t))) == NULL) {
                     apdu_response_code = APDU_RESPONSE_INSUFFICIENT_MEMORY;
                     return false;
                 }
@@ -627,7 +627,7 @@ static bool set_struct_field_typesize(const uint8_t *const data,
         apdu_response_code = APDU_RESPONSE_INVALID_DATA;
         return false;
     }
-    if ((typesize_ptr = mem_alloc(sizeof(uint8_t))) == NULL) {
+    if ((typesize_ptr = mem_legacy_alloc(sizeof(uint8_t))) == NULL) {
         apdu_response_code = APDU_RESPONSE_INSUFFICIENT_MEMORY;
         return false;
     }
@@ -652,7 +652,7 @@ static bool set_struct_field_keyname(const uint8_t *const data, uint8_t *data_id
         apdu_response_code = APDU_RESPONSE_INVALID_DATA;
         return false;
     }
-    if ((keyname_len_ptr = mem_alloc(sizeof(uint8_t))) == NULL) {
+    if ((keyname_len_ptr = mem_legacy_alloc(sizeof(uint8_t))) == NULL) {
         apdu_response_code = APDU_RESPONSE_INSUFFICIENT_MEMORY;
         return false;
     }
@@ -664,7 +664,7 @@ static bool set_struct_field_keyname(const uint8_t *const data, uint8_t *data_id
         apdu_response_code = APDU_RESPONSE_INVALID_DATA;
         return false;
     }
-    if ((keyname_ptr = mem_alloc(sizeof(char) * *keyname_len_ptr)) == NULL) {
+    if ((keyname_ptr = mem_legacy_alloc(sizeof(char) * *keyname_len_ptr)) == NULL) {
         apdu_response_code = APDU_RESPONSE_INSUFFICIENT_MEMORY;
         return false;
     }

--- a/src_nbgl/ui_gcs.c
+++ b/src_nbgl/ui_gcs.c
@@ -10,8 +10,9 @@
 #include "apdu_constants.h"
 #include "cmd_get_tx_simulation.h"
 
-static nbgl_layoutTagValueList_t g_pair_list;
-static size_t g_alloc_size;
+static nbgl_contentTagValueList_t *g_pair_list = NULL;
+static char *g_review_title = NULL;
+static char *g_sign_title = NULL;
 
 static void review_choice(bool confirm) {
     if (confirm) {
@@ -27,15 +28,69 @@ static char *_strdup(const char *src) {
     char *dst;
     size_t length = strlen(src) + 1;
 
-    if ((dst = mem_legacy_alloc(length)) != NULL) {
+    if ((dst = app_mem_alloc(length)) != NULL) {
         memmove(dst, src, length);
     }
     return dst;
 }
 
-static bool cleanup_on_error(const void *mem_before) {
-    mem_legacy_dealloc(mem_legacy_alloc(0) - mem_before);
-    return false;
+static void free_pair_extension_infolist_elem(const struct nbgl_contentInfoList_s *infolist,
+                                              int idx) {
+    if (infolist->infoTypes[idx] != NULL) {
+        app_mem_free((void *) infolist->infoTypes[idx]);
+    }
+    if (infolist->infoContents[idx] != NULL) {
+        app_mem_free((void *) infolist->infoContents[idx]);
+    }
+    if (infolist->infoExtensions != NULL) {
+        if (infolist->infoExtensions[idx].title != NULL) {
+            app_mem_free((void *) infolist->infoExtensions[idx].title);
+        }
+        if (infolist->infoExtensions[idx].explanation != NULL) {
+            app_mem_free((void *) infolist->infoExtensions[idx].explanation);
+        }
+        if (infolist->infoExtensions[idx].fullValue != NULL) {
+            app_mem_free((void *) infolist->infoExtensions[idx].fullValue);
+        }
+    }
+}
+
+static void free_pair_extension(const nbgl_contentValueExt_t *ext) {
+    if (ext->backText != NULL) {
+        app_mem_free((void *) ext->backText);
+    }
+    if (ext->infolist != NULL) {
+        for (int i = 0; i < ext->infolist->nbInfos; ++i) {
+            free_pair_extension_infolist_elem(ext->infolist, i);
+        }
+        if (ext->infolist->infoTypes != NULL) {
+            app_mem_free((void *) ext->infolist->infoTypes);
+        }
+        if (ext->infolist->infoContents != NULL) {
+            app_mem_free((void *) ext->infolist->infoContents);
+        }
+
+        if (ext->infolist->infoExtensions != NULL) {
+            app_mem_free((void *) ext->infolist->infoExtensions);
+        }
+        app_mem_free((void *) ext->infolist);
+    }
+    app_mem_free((void *) ext);
+}
+
+static void free_pair(const nbgl_contentTagValueList_t *pair_list, int idx) {
+    // Only a few pairs are created from the UI, and need to be freed :
+    // - the first one, that leads to the contract infos
+    // - the second to last one, that shows the Network (optional)
+    // - the last one, that shows the TX fees
+    if ((idx == 0) || (idx == (pair_list->nbPairs - 1)) ||
+        ((get_tx_chain_id() != chainConfig->chainId) && (idx == (pair_list->nbPairs - 2)))) {
+        if (pair_list->pairs[idx].item != NULL) app_mem_free((void *) pair_list->pairs[idx].item);
+        if (pair_list->pairs[idx].value != NULL) app_mem_free((void *) pair_list->pairs[idx].value);
+    }
+    if (pair_list->pairs[idx].extension != NULL) {
+        free_pair_extension(pair_list->pairs[idx].extension);
+    }
 }
 
 #define MAX_INFO_COUNT 3
@@ -51,12 +106,15 @@ static bool prepare_infos(nbgl_contentInfoList_t *infos) {
     const char *value;
     int contract_idx = -1;
 
-    if (((keys = mem_legacy_alloc_and_align(sizeof(*keys) * MAX_INFO_COUNT, __alignof__(*keys))) ==
-         NULL) ||
-        ((values = mem_legacy_alloc_and_align(sizeof(*values) * MAX_INFO_COUNT,
-                                              __alignof__(*values))) == NULL)) {
-        return false;
-    }
+    infos->nbInfos = MAX_INFO_COUNT;
+    if ((keys = app_mem_alloc(sizeof(*keys) * MAX_INFO_COUNT)) == NULL) return false;
+    explicit_bzero(keys, sizeof(*keys) * MAX_INFO_COUNT);
+    infos->infoTypes = keys;
+
+    if ((values = app_mem_alloc(sizeof(*values) * MAX_INFO_COUNT)) == NULL) return false;
+    explicit_bzero(keys, sizeof(*values) * MAX_INFO_COUNT);
+    infos->infoContents = values;
+
     if ((value = get_creator_legal_name()) != NULL) {
         snprintf(tmp_buf, tmp_buf_size, "Smart contract owner");
         if ((keys[count] = _strdup(tmp_buf)) == NULL) {
@@ -98,13 +156,14 @@ static bool prepare_infos(nbgl_contentInfoList_t *infos) {
         count += 1;
     }
 
-    if ((extensions = mem_legacy_alloc_and_align(sizeof(*extensions) * count,
-                                                 __alignof__(*extensions))) == NULL) {
-        return false;
-    }
-    explicit_bzero(extensions, sizeof(*extensions) * count);
-
     if (contract_idx != -1) {
+        if ((extensions = app_mem_alloc(sizeof(*extensions) * count)) == NULL) {
+            return false;
+        }
+        explicit_bzero(extensions, sizeof(*extensions) * count);
+        infos->infoExtensions = extensions;
+        infos->withExtensions = true;
+
         if (!getEthDisplayableAddress((uint8_t *) get_contract_addr(),
                                       tmp_buf,
                                       tmp_buf_size,
@@ -134,24 +193,38 @@ static bool prepare_infos(nbgl_contentInfoList_t *infos) {
     }
 
     infos->nbInfos = count;
-    infos->infoTypes = keys;
-    infos->infoContents = values;
-    infos->infoExtensions = extensions;
-    infos->withExtensions = true;
     return true;
+}
+
+void ui_gcs_cleanup(void) {
+    if (g_review_title != NULL) {
+        app_mem_free(g_review_title);
+        g_review_title = NULL;
+    }
+    if (g_sign_title != NULL) {
+        app_mem_free(g_sign_title);
+        g_sign_title = NULL;
+    }
+    if (g_pair_list != NULL) {
+        if (g_pair_list->pairs != NULL) {
+            for (int i = 0; i < g_pair_list->nbPairs; ++i) {
+                free_pair(g_pair_list, i);
+            }
+            app_mem_free((void *) g_pair_list->pairs);
+        }
+        app_mem_free(g_pair_list);
+        g_pair_list = NULL;
+    }
 }
 
 bool ui_gcs(void) {
     char *tmp_buf = strings.tmp.tmp;
     size_t tmp_buf_size = sizeof(strings.tmp.tmp);
-    const char *review_title;
-    const char *sign_title;
-    nbgl_contentTagValue_t *pairs;
-    s_field_table_entry entry;
+    nbgl_contentTagValue_t *pairs = NULL;
+    const s_field_table_entry *field;
     bool show_network;
-    nbgl_contentValueExt_t *ext;
-    nbgl_contentInfoList_t *infolist;
-    const void *mem_before = mem_legacy_alloc(0);
+    nbgl_contentValueExt_t *ext = NULL;
+    nbgl_contentInfoList_t *infolist = NULL;
 
     explicit_bzero(&warning, sizeof(nbgl_warning_t));
 #ifdef HAVE_WEB3_CHECKS
@@ -159,100 +232,113 @@ bool ui_gcs(void) {
 #endif
 
     snprintf(tmp_buf, tmp_buf_size, "Review transaction to %s", get_operation_type());
-    if ((review_title = _strdup(tmp_buf)) == NULL) {
-        return cleanup_on_error(mem_before);
+    if ((g_review_title = _strdup(tmp_buf)) == NULL) {
+        ui_gcs_cleanup();
+        return false;
     }
     snprintf(tmp_buf,
              tmp_buf_size,
              "%s transaction to %s?",
              ui_tx_simulation_finish_str(),
              get_operation_type());
-    if ((sign_title = _strdup(tmp_buf)) == NULL) {
-        return cleanup_on_error(mem_before);
+    if ((g_sign_title = _strdup(tmp_buf)) == NULL) {
+        ui_gcs_cleanup();
+        return false;
     }
 
-    explicit_bzero(&g_pair_list, sizeof(g_pair_list));
+    if ((g_pair_list = app_mem_alloc(sizeof(*g_pair_list))) == NULL) {
+        ui_gcs_cleanup();
+        return false;
+    }
+    explicit_bzero(g_pair_list, sizeof(*g_pair_list));
+
     // Contract info
-    g_pair_list.nbPairs += 1;
+    g_pair_list->nbPairs += 1;
     // TX fields
-    g_pair_list.nbPairs += field_table_size();
+    g_pair_list->nbPairs += field_table_size();
     show_network = get_tx_chain_id() != chainConfig->chainId;
     if (show_network) {
-        g_pair_list.nbPairs += 1;
+        g_pair_list->nbPairs += 1;
     }
     // Fees
-    g_pair_list.nbPairs += 1;
+    g_pair_list->nbPairs += 1;
 
-    if ((pairs = mem_legacy_alloc_and_align(sizeof(*pairs) * g_pair_list.nbPairs,
-                                            __alignof__(*pairs))) == NULL) {
-        return cleanup_on_error(mem_before);
+    if ((pairs = app_mem_alloc(sizeof(*pairs) * g_pair_list->nbPairs)) == NULL) {
+        ui_gcs_cleanup();
+        return false;
     }
-    explicit_bzero(pairs, sizeof(*pairs) * g_pair_list.nbPairs);
+    explicit_bzero(pairs, sizeof(*pairs) * g_pair_list->nbPairs);
+    g_pair_list->pairs = pairs;
 
     pairs[0].item = _strdup("Interaction with");
     pairs[0].value = get_creator_name();
     if (pairs[0].value == NULL) {
         // not great, but this cannot be NULL
         pairs[0].value = _strdup("a smart contract");
+    } else {
+        pairs[0].value = _strdup(pairs[0].value);
     }
-    if ((ext = mem_legacy_alloc_and_align(sizeof(*ext), __alignof__(*ext))) == NULL) {
-        return cleanup_on_error(mem_before);
+    if ((ext = app_mem_alloc(sizeof(*ext))) == NULL) {
+        ui_gcs_cleanup();
+        return false;
     }
     explicit_bzero(ext, sizeof(*ext));
-    if ((infolist = mem_legacy_alloc_and_align(sizeof(*infolist), __alignof__(*infolist))) ==
-        NULL) {
-        return cleanup_on_error(mem_before);
+    pairs[0].extension = ext;
+
+    if ((infolist = app_mem_alloc(sizeof(*infolist))) == NULL) {
+        ui_gcs_cleanup();
+        return false;
     }
-    if (!prepare_infos(infolist)) {
-        return cleanup_on_error(mem_before);
-    }
+    explicit_bzero(infolist, sizeof(*infolist));
     ext->infolist = infolist;
+
+    if (!prepare_infos(infolist)) {
+        ui_gcs_cleanup();
+        return false;
+    }
     ext->aliasType = INFO_LIST_ALIAS;
     if ((ext->backText = get_creator_name()) == NULL) {
         ext->backText = _strdup("Smart contract information");
+    } else {
+        ext->backText = _strdup(ext->backText);
     }
-    pairs[0].extension = ext;
     pairs[0].aliasValue = 1;
 
     for (int i = 0; i < (int) field_table_size(); ++i) {
-        if (!get_from_field_table(i, &entry)) {
-            return cleanup_on_error(mem_before);
+        if ((field = get_from_field_table(i)) == NULL) {
+            ui_gcs_cleanup();
+            return false;
         }
-        pairs[1 + i].item = entry.key;
-        pairs[1 + i].value = entry.value;
+        pairs[1 + i].item = field->key;
+        pairs[1 + i].value = field->value;
     }
 
     if (show_network) {
-        pairs[g_pair_list.nbPairs - 2].item = _strdup("Network");
+        pairs[g_pair_list->nbPairs - 2].item = _strdup("Network");
         if (get_network_as_string(tmp_buf, tmp_buf_size) != APDU_RESPONSE_OK) {
-            return cleanup_on_error(mem_before);
+            ui_gcs_cleanup();
+            return false;
         }
-        pairs[g_pair_list.nbPairs - 2].value = _strdup(tmp_buf);
+        pairs[g_pair_list->nbPairs - 2].value = _strdup(tmp_buf);
     }
 
-    pairs[g_pair_list.nbPairs - 1].item = _strdup("Max fees");
+    pairs[g_pair_list->nbPairs - 1].item = _strdup("Max fees");
     if (max_transaction_fee_to_string(&tmpContent.txContent.gasprice,
                                       &tmpContent.txContent.startgas,
                                       tmp_buf,
                                       tmp_buf_size) == false) {
         PRINTF("Error: Could not format the max fees!\n");
     }
-    pairs[g_pair_list.nbPairs - 1].value = _strdup(tmp_buf);
-    g_pair_list.pairs = pairs;
+    pairs[g_pair_list->nbPairs - 1].value = _strdup(tmp_buf);
 
     nbgl_useCaseAdvancedReview(TYPE_TRANSACTION,
-                               &g_pair_list,
+                               g_pair_list,
                                get_tx_icon(),
-                               review_title,
+                               g_review_title,
                                NULL,
-                               sign_title,
+                               g_sign_title,
                                NULL,
                                &warning,
                                review_choice);
-    g_alloc_size = mem_legacy_alloc(0) - mem_before;
     return true;
-}
-
-void ui_gcs_cleanup(void) {
-    mem_legacy_dealloc(g_alloc_size);
 }

--- a/src_nbgl/ui_gcs.c
+++ b/src_nbgl/ui_gcs.c
@@ -27,14 +27,14 @@ static char *_strdup(const char *src) {
     char *dst;
     size_t length = strlen(src) + 1;
 
-    if ((dst = mem_alloc(length)) != NULL) {
+    if ((dst = mem_legacy_alloc(length)) != NULL) {
         memmove(dst, src, length);
     }
     return dst;
 }
 
 static bool cleanup_on_error(const void *mem_before) {
-    mem_dealloc(mem_alloc(0) - mem_before);
+    mem_legacy_dealloc(mem_legacy_alloc(0) - mem_before);
     return false;
 }
 
@@ -51,10 +51,10 @@ static bool prepare_infos(nbgl_contentInfoList_t *infos) {
     const char *value;
     int contract_idx = -1;
 
-    if (((keys = mem_alloc_and_align(sizeof(*keys) * MAX_INFO_COUNT, __alignof__(*keys))) ==
+    if (((keys = mem_legacy_alloc_and_align(sizeof(*keys) * MAX_INFO_COUNT, __alignof__(*keys))) ==
          NULL) ||
-        ((values = mem_alloc_and_align(sizeof(*values) * MAX_INFO_COUNT, __alignof__(*values))) ==
-         NULL)) {
+        ((values = mem_legacy_alloc_and_align(sizeof(*values) * MAX_INFO_COUNT,
+                                              __alignof__(*values))) == NULL)) {
         return false;
     }
     if ((value = get_creator_legal_name()) != NULL) {
@@ -98,8 +98,8 @@ static bool prepare_infos(nbgl_contentInfoList_t *infos) {
         count += 1;
     }
 
-    if ((extensions = mem_alloc_and_align(sizeof(*extensions) * count, __alignof__(*extensions))) ==
-        NULL) {
+    if ((extensions = mem_legacy_alloc_and_align(sizeof(*extensions) * count,
+                                                 __alignof__(*extensions))) == NULL) {
         return false;
     }
     explicit_bzero(extensions, sizeof(*extensions) * count);
@@ -151,7 +151,7 @@ bool ui_gcs(void) {
     bool show_network;
     nbgl_contentValueExt_t *ext;
     nbgl_contentInfoList_t *infolist;
-    const void *mem_before = mem_alloc(0);
+    const void *mem_before = mem_legacy_alloc(0);
 
     explicit_bzero(&warning, sizeof(nbgl_warning_t));
 #ifdef HAVE_WEB3_CHECKS
@@ -183,8 +183,8 @@ bool ui_gcs(void) {
     // Fees
     g_pair_list.nbPairs += 1;
 
-    if ((pairs = mem_alloc_and_align(sizeof(*pairs) * g_pair_list.nbPairs, __alignof__(*pairs))) ==
-        NULL) {
+    if ((pairs = mem_legacy_alloc_and_align(sizeof(*pairs) * g_pair_list.nbPairs,
+                                            __alignof__(*pairs))) == NULL) {
         return cleanup_on_error(mem_before);
     }
     explicit_bzero(pairs, sizeof(*pairs) * g_pair_list.nbPairs);
@@ -195,11 +195,12 @@ bool ui_gcs(void) {
         // not great, but this cannot be NULL
         pairs[0].value = _strdup("a smart contract");
     }
-    if ((ext = mem_alloc_and_align(sizeof(*ext), __alignof__(*ext))) == NULL) {
+    if ((ext = mem_legacy_alloc_and_align(sizeof(*ext), __alignof__(*ext))) == NULL) {
         return cleanup_on_error(mem_before);
     }
     explicit_bzero(ext, sizeof(*ext));
-    if ((infolist = mem_alloc_and_align(sizeof(*infolist), __alignof__(*infolist))) == NULL) {
+    if ((infolist = mem_legacy_alloc_and_align(sizeof(*infolist), __alignof__(*infolist))) ==
+        NULL) {
         return cleanup_on_error(mem_before);
     }
     if (!prepare_infos(infolist)) {
@@ -248,10 +249,10 @@ bool ui_gcs(void) {
                                NULL,
                                &warning,
                                review_choice);
-    g_alloc_size = mem_alloc(0) - mem_before;
+    g_alloc_size = mem_legacy_alloc(0) - mem_before;
     return true;
 }
 
 void ui_gcs_cleanup(void) {
-    mem_dealloc(g_alloc_size);
+    mem_legacy_dealloc(g_alloc_size);
 }

--- a/tests/fuzzing/CMakeLists.txt
+++ b/tests/fuzzing/CMakeLists.txt
@@ -193,6 +193,7 @@ include_directories(
   ${BOLOS_SDK}/lib_ux_nbgl
   ${BOLOS_SDK}/lib_nbgl/include
   ${BOLOS_SDK}/lib_standard_app/
+  ${BOLOS_SDK}/lib_alloc/
   ${CMAKE_SOURCE_DIR}/src/
 )
 

--- a/tests/fuzzing/src/fuzzer.c
+++ b/tests/fuzzing/src/fuzzer.c
@@ -22,7 +22,6 @@
 
 #include "shared_context.h"
 #include "tlv.h"
-#include "mem.h"
 #include "apdu_constants.h"
 
 // Fuzzing harness interface
@@ -143,7 +142,6 @@ int fuzzCalldata(const uint8_t *data, size_t size) {
             case 'I':
                 data++;
                 size--;
-                mem_reset();
                 calldata_init(500);
                 break;
             case 'W':
@@ -214,7 +212,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     explicit_bzero(&global_sha3, sizeof(global_sha3));
 
     calldata_cleanup();
-    mem_reset();
 
     uint8_t target;
 

--- a/tests/fuzzing/src/mock.c
+++ b/tests/fuzzing/src/mock.c
@@ -6,6 +6,7 @@
 #include "cx_sha3.h"
 #include "buffer.h"
 #include "lcx_ecfp.h"
+#include "mem_alloc.h"
 
 #include "bip32_utils.h"
 
@@ -311,4 +312,19 @@ const uint8_t *parseBip32(const uint8_t *dataBuffer, uint8_t *dataLength, bip32_
     *dataLength -= bip32->length * sizeof(uint32_t);
 
     return dataBuffer;
+}
+
+mem_ctx_t mem_init(void *heap_start, size_t heap_size) {
+    (void) heap_size;
+    return heap_start;
+}
+
+void *mem_alloc(mem_ctx_t ctx, size_t nb_bytes) {
+    (void) ctx;
+    return malloc(nb_bytes);
+}
+
+void mem_free(mem_ctx_t ctx, void *ptr) {
+    (void) ctx;
+    free(ptr);
 }

--- a/tools/valground.py
+++ b/tools/valground.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# Compile the app with MEMORY_PROFILING=1 and feed the speculos output to this script :
+# pytest --device nanosp -s -k my_special_test 2>&1 | ./valground.py
+
+import sys
+
+
+class Allocation:
+    size: int
+    code_location: str
+
+    def __init__(self, size: int, code_location: str):
+        self.size = size
+        self.code_location = code_location
+
+
+class Memory:
+    allocs: dict[Allocation]
+    allocd_overtime: int
+    allocd_max: int
+    allocd_current: int
+    alloc_count: int
+
+    def __init__(self):
+        self.allocs = {}
+        self.allocd_overtime = 0
+        self.allocd_max = 0
+        self.allocd_current = 0
+        self.alloc_count = 0
+
+    def alloc(self, ptr: int, size: int, code_loc: str):
+        self.allocs[ptr] = Allocation(size, code_loc)
+        self.allocd_current += size
+        if self.allocd_current > self.allocd_max:
+            self.allocd_max = self.allocd_current
+        self.allocd_overtime += size
+        self.alloc_count += 1
+
+    def free(self, ptr: int, code_loc: str):
+        assert ptr in self.allocs
+        self.allocd_current -= self.allocs[ptr].size
+        del self.allocs[ptr]
+
+
+mem = Memory()
+
+for line in sys.stdin:
+    line = line.rstrip()
+    scheme = "seproxyhal: printf: "
+    if line.startswith(scheme):
+        line = line[len(scheme):]
+        scheme = "==MP "
+        if line.startswith(scheme):
+            line = line[len(scheme):]
+            words = line.split(";")
+            assert len(words) > 2
+
+            if words[0] == "alloc":
+                mem.alloc(int(words[2], base=0), int(words[1], base=0), words[3])
+            elif words[0] == "free":
+                mem.free(int(words[1], base=0), words[2])
+            else:
+                assert False
+
+if len(mem.allocs) == 0:
+    print("No memory leak detected, congrats!")
+else:
+    print("Memory leaks :")
+    for addr, info in mem.allocs.items():
+        print("- [0x%.08x] %u bytes from %s" % (addr, info.size, info.code_location))
+
+print("\n=== Summary ===")
+print("Total overtime = %u bytes" % (mem.allocd_overtime))
+print("Max overtime = %u bytes" % (mem.allocd_max))
+print("Allocations = %u" % (mem.alloc_count))


### PR DESCRIPTION
## Description

For easier maintainability and safer code.
EIP-712 will have to be migrated as well.

The clang static analysis is :red_circle: but it comes from the SDK, which has already been fixed and a new app-builder container will have to be published.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)