### PR TITLE
Realign workflows

### DIFF
--- a/.github/workflows/build_and_functional_tests.yml
+++ b/.github/workflows/build_and_functional_tests.yml
@@ -32,7 +32,7 @@ jobs:
     uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_build.yml@v1
     with:
       upload_app_binaries_artifact: "ragger_elfs"
-      flags: "EIP7702_TEST_WHITELIST=1"
+      flags: "whitelist_keys"
 
   ragger_tests:
     name: Run ragger tests using the reusable workflow

--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -47,5 +47,6 @@ jobs:
       publish: ${{ startsWith(github.ref, 'refs/tags/') }}
       package_directory: ./client/
       jfrog_deployment: false
+      release: false
     secrets:
       pypi_token: ${{ secrets.PYPI_PUBLIC_API_TOKEN  }}


### PR DESCRIPTION

Do not release a Python package in the repo itself
Set use-case name instead of compilation flags