### PR TITLE
Improve memory management

### DIFF
--- a/.github/workflows/build_and_functional_tests.yml
+++ b/.github/workflows/build_and_functional_tests.yml
@@ -61,3 +61,21 @@ jobs:
       additional_app_binaries_artifact_dir: ./tests/ragger/.test_dependencies/clone/build/
       test_options: "--setup lib_mode"
       regenerate_snapshots: ${{ inputs.golden_run == 'Open a PR' }}
+
+  build_mem_app:
+    name: Build Memory application using the reusable workflow
+    uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_build.yml@v1
+    with:
+      upload_app_binaries_artifact: "memory_elfs"
+      flags: "memory_profiling"
+      run_for_devices: '["nanox"]'
+
+  ragger_mem_tests:
+    name: Run Memory tests using the reusable workflow
+    needs: build_application
+    uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_ragger_tests.yml@v1
+    with:
+      download_app_binaries_artifact: "memory_elfs"
+      test_options: " -s 2>&1 | tools/valground.py -q"
+      run_for_devices: '["nanox"]'
+      upload_snapshots_on_failure: false

--- a/src/mem.c
+++ b/src/mem.c
@@ -31,17 +31,19 @@ bool app_mem_init(void) {
     return mem_ctx != NULL;
 }
 
-void *app_mem_alloc_impl(size_t size, const char *file, int line) {
+void *app_mem_alloc_impl(size_t size, bool persistent, const char *file, int line) {
     void *ptr;
     ptr = mem_alloc(mem_ctx, size);
 #ifdef HAVE_MEMORY_PROFILING
-    if ((file != NULL) && (line > 0)) {
-        // Do not track the allocation in logs, because this buffer is expected to stay allocated
+    if (persistent) {
+        PRINTF(MP_LOG_PREFIX "persist;%u;0x%p;%s:%u\n", size, ptr, file, line);
+    } else {
         PRINTF(MP_LOG_PREFIX "alloc;%u;0x%p;%s:%u\n", size, ptr, file, line);
     }
 #else
     (void) file;
     (void) line;
+    (void) persistent;
 #endif
     return ptr;
 }

--- a/src/mem.c
+++ b/src/mem.c
@@ -35,7 +35,10 @@ void *app_mem_alloc_impl(size_t size, const char *file, int line) {
     void *ptr;
     ptr = mem_alloc(mem_ctx, size);
 #ifdef HAVE_MEMORY_PROFILING
-    PRINTF(MP_LOG_PREFIX "alloc;%u;0x%p;%s:%u\n", size, ptr, file, line);
+    if ((file != NULL) && (line > 0)) {
+        // Do not track the allocation in logs, because this buffer is expected to stay allocated
+        PRINTF(MP_LOG_PREFIX "alloc;%u;0x%p;%s:%u\n", size, ptr, file, line);
+    }
 #else
     (void) file;
     (void) line;

--- a/src/mem.h
+++ b/src/mem.h
@@ -11,9 +11,9 @@
 #define MP_FILE NULL
 #define MP_LINE 0
 #endif
-#define app_mem_alloc(size) app_mem_alloc_impl(size, MP_FILE, MP_LINE)
+#define app_mem_alloc(size) app_mem_alloc_impl(size, false, MP_FILE, MP_LINE)
 #define app_mem_free(ptr)   app_mem_free_impl(ptr, MP_FILE, MP_LINE)
 
 bool app_mem_init(void);
-void *app_mem_alloc_impl(size_t size, const char *file, int line);
+void *app_mem_alloc_impl(size_t size, bool persistent, const char *file, int line);
 void app_mem_free_impl(void *ptr, const char *file, int line);

--- a/src/mem_utils.c
+++ b/src/mem_utils.c
@@ -23,7 +23,7 @@ const char *mem_alloc_and_format_uint_impl(uint32_t value, const char *file, int
         size += 1;
     }
     // +1 for the null character
-    if ((mem_ptr = app_mem_alloc_impl(sizeof(char) * (size + 1), file, line))) {
+    if ((mem_ptr = app_mem_alloc_impl(sizeof(char) * (size + 1), false, file, line))) {
         snprintf(mem_ptr, (size + 1), "%u", value);
     }
     return mem_ptr;
@@ -33,7 +33,7 @@ char *app_mem_strdup_impl(const char *src, const char *file, int line) {
     char *dst;
     size_t length = strlen(src) + 1;
 
-    if ((dst = app_mem_alloc_impl(length, file, line)) != NULL) {
+    if ((dst = app_mem_alloc_impl(length, false, file, line)) != NULL) {
         memcpy(dst, src, length);
     }
     return dst;
@@ -44,9 +44,14 @@ char *app_mem_strdup_impl(const char *src, const char *file, int line) {
  *
  * @param[out] buffer Pointer to the buffer to allocate
  * @param[in] size Size of the buffer to allocate
+ * @param[in] persistent Whether the buffer should be persistent
  * @return true if the allocation was successful, false otherwise
  */
-bool mem_buffer_allocate_impl(void **buffer, uint16_t size, const char *file, int line) {
+bool mem_buffer_allocate_impl(void **buffer,
+                              uint16_t size,
+                              bool persistent,
+                              const char *file,
+                              int line) {
     if (size != 0) {
         // Check if the buffer is already allocated
         if (*buffer != NULL) {
@@ -54,7 +59,7 @@ bool mem_buffer_allocate_impl(void **buffer, uint16_t size, const char *file, in
             app_mem_free_impl(*buffer, file, line);
         }
         // Allocate the Title message buffer
-        if ((*buffer = app_mem_alloc_impl(size, file, line)) == NULL) {
+        if ((*buffer = app_mem_alloc_impl(size, persistent, file, line)) == NULL) {
             PRINTF("Memory allocation failed for buffer of size %u\n", size);
             return false;
         }

--- a/src/mem_utils.c
+++ b/src/mem_utils.c
@@ -11,7 +11,7 @@
  * @param[in] value Value to write in memory
  * @return pointer to memory area or \ref NULL if the allocation failed
  */
-const char *mem_alloc_and_format_uint(uint32_t value) {
+const char *mem_alloc_and_format_uint_impl(uint32_t value, const char *file, int line) {
     char *mem_ptr;
     uint32_t value_copy;
     uint8_t size;
@@ -23,17 +23,17 @@ const char *mem_alloc_and_format_uint(uint32_t value) {
         size += 1;
     }
     // +1 for the null character
-    if ((mem_ptr = app_mem_alloc(sizeof(char) * (size + 1)))) {
+    if ((mem_ptr = app_mem_alloc_impl(sizeof(char) * (size + 1), file, line))) {
         snprintf(mem_ptr, (size + 1), "%u", value);
     }
     return mem_ptr;
 }
 
-char *app_mem_strdup(const char *src) {
+char *app_mem_strdup_impl(const char *src, const char *file, int line) {
     char *dst;
     size_t length = strlen(src) + 1;
 
-    if ((dst = app_mem_alloc(length)) != NULL) {
+    if ((dst = app_mem_alloc_impl(length, file, line)) != NULL) {
         memcpy(dst, src, length);
     }
     return dst;
@@ -46,15 +46,15 @@ char *app_mem_strdup(const char *src) {
  * @param[in] size Size of the buffer to allocate
  * @return true if the allocation was successful, false otherwise
  */
-bool mem_buffer_allocate(void **buffer, uint16_t size) {
+bool mem_buffer_allocate_impl(void **buffer, uint16_t size, const char *file, int line) {
     if (size != 0) {
         // Check if the buffer is already allocated
         if (*buffer != NULL) {
             PRINTF("Buffer already allocated, freeing it before reallocating\n");
-            app_mem_free(*buffer);
+            app_mem_free_impl(*buffer, file, line);
         }
         // Allocate the Title message buffer
-        if ((*buffer = app_mem_alloc(size)) == NULL) {
+        if ((*buffer = app_mem_alloc_impl(size, file, line)) == NULL) {
             PRINTF("Memory allocation failed for buffer of size %u\n", size);
             return false;
         }
@@ -68,9 +68,9 @@ bool mem_buffer_allocate(void **buffer, uint16_t size) {
  *
  * @param[in] buffer Pointer to the buffer to deallocate
  */
-void mem_buffer_cleanup(void **buffer) {
+void mem_buffer_cleanup_impl(void **buffer, const char *file, int line) {
     if (*buffer != NULL) {
-        app_mem_free(*buffer);
+        app_mem_free_impl(*buffer, file, line);
         *buffer = NULL;
     }
 }

--- a/src/mem_utils.h
+++ b/src/mem_utils.h
@@ -2,8 +2,20 @@
 
 #include <stdint.h>
 
-const char *mem_alloc_and_format_uint(uint32_t value);
-char *app_mem_strdup(const char *s);
+#ifdef HAVE_MEMORY_PROFILING
+#define MP_FILE __FILE__
+#define MP_LINE __LINE__
+#else
+#define MP_FILE NULL
+#define MP_LINE 0
+#endif
+#define mem_buffer_allocate(ptr, size)   mem_buffer_allocate_impl(ptr, size, MP_FILE, MP_LINE)
+#define mem_buffer_cleanup(ptr)          mem_buffer_cleanup_impl(ptr, MP_FILE, MP_LINE)
+#define mem_alloc_and_format_uint(value) mem_alloc_and_format_uint_impl(value, MP_FILE, MP_LINE)
+#define app_mem_strdup(ptr)              app_mem_strdup_impl(ptr, MP_FILE, MP_LINE)
 
-bool mem_buffer_allocate(void **buffer, uint16_t size);
-void mem_buffer_cleanup(void **buffer);
+const char *mem_alloc_and_format_uint_impl(uint32_t value, const char *file, int line);
+char *app_mem_strdup_impl(const char *s, const char *file, int line);
+
+bool mem_buffer_allocate_impl(void **buffer, uint16_t size, const char *file, int line);
+void mem_buffer_cleanup_impl(void **buffer, const char *file, int line);

--- a/src/mem_utils.h
+++ b/src/mem_utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef HAVE_MEMORY_PROFILING
@@ -9,7 +10,8 @@
 #define MP_FILE NULL
 #define MP_LINE 0
 #endif
-#define mem_buffer_allocate(ptr, size)   mem_buffer_allocate_impl(ptr, size, MP_FILE, MP_LINE)
+#define mem_buffer_allocate(ptr, size)   mem_buffer_allocate_impl(ptr, size, false, MP_FILE, MP_LINE)
+#define mem_buffer_persistent(ptr, size) mem_buffer_allocate_impl(ptr, size, true, MP_FILE, MP_LINE)
 #define mem_buffer_cleanup(ptr)          mem_buffer_cleanup_impl(ptr, MP_FILE, MP_LINE)
 #define mem_alloc_and_format_uint(value) mem_alloc_and_format_uint_impl(value, MP_FILE, MP_LINE)
 #define app_mem_strdup(ptr)              app_mem_strdup_impl(ptr, MP_FILE, MP_LINE)
@@ -17,5 +19,9 @@
 const char *mem_alloc_and_format_uint_impl(uint32_t value, const char *file, int line);
 char *app_mem_strdup_impl(const char *s, const char *file, int line);
 
-bool mem_buffer_allocate_impl(void **buffer, uint16_t size, const char *file, int line);
+bool mem_buffer_allocate_impl(void **buffer,
+                              uint16_t size,
+                              bool persistent,
+                              const char *file,
+                              int line);
 void mem_buffer_cleanup_impl(void **buffer, const char *file, int line);

--- a/src_features/provide_network_info/cmd_network_info.c
+++ b/src_features/provide_network_info/cmd_network_info.c
@@ -139,10 +139,8 @@ static uint16_t handle_first_icon_chunk(const uint8_t *data, uint8_t length) {
     }
 
     // Do not track the allocation in logs, because this buffer is expected to stay allocated
-    if (mem_buffer_allocate_impl((void **) &(g_icon_bitmap[g_current_network_slot]),
-                                 img_len,
-                                 NULL,
-                                 0) == false) {
+    if (mem_buffer_persistent((void **) &(g_icon_bitmap[g_current_network_slot]), img_len) ==
+        false) {
         PRINTF("Error: Not enough memory for icon bitmap!\n");
         return APDU_RESPONSE_INSUFFICIENT_MEMORY;
     }
@@ -362,14 +360,14 @@ void network_info_cleanup(uint8_t slot) {
     if (slot == MAX_DYNAMIC_NETWORKS) {
         // Cleanup all slots
         for (slot = 0; slot < MAX_DYNAMIC_NETWORKS; slot++) {
-            mem_buffer_cleanup_impl((void **) &(g_icon_bitmap[slot]), NULL, 0);
-            mem_buffer_cleanup_impl((void **) &(DYNAMIC_NETWORK_INFO[slot]), NULL, 0);
+            mem_buffer_cleanup((void **) &(g_icon_bitmap[slot]));
+            mem_buffer_cleanup((void **) &(DYNAMIC_NETWORK_INFO[slot]));
         }
     } else {
         // Cleanup only the specified slot
-        mem_buffer_cleanup_impl((void **) &(g_icon_bitmap[slot]), NULL, 0);
-        mem_buffer_cleanup_impl((void **) &(DYNAMIC_NETWORK_INFO[slot]), NULL, 0);
+        mem_buffer_cleanup((void **) &(g_icon_bitmap[slot]));
+        mem_buffer_cleanup((void **) &(DYNAMIC_NETWORK_INFO[slot]));
     }
     // Free the icon hash if it was allocated
-    mem_buffer_cleanup_impl((void **) &g_network_icon_hash, NULL, 0);
+    mem_buffer_cleanup((void **) &g_network_icon_hash);
 }

--- a/src_features/provide_network_info/cmd_network_info.c
+++ b/src_features/provide_network_info/cmd_network_info.c
@@ -138,7 +138,11 @@ static uint16_t handle_first_icon_chunk(const uint8_t *data, uint8_t length) {
         return APDU_RESPONSE_INVALID_DATA;
     }
 
-    if (mem_buffer_allocate((void **) &(g_icon_bitmap[g_current_network_slot]), img_len) == false) {
+    // Do not track the allocation in logs, because this buffer is expected to stay allocated
+    if (mem_buffer_allocate_impl((void **) &(g_icon_bitmap[g_current_network_slot]),
+                                 img_len,
+                                 NULL,
+                                 0) == false) {
         PRINTF("Error: Not enough memory for icon bitmap!\n");
         return APDU_RESPONSE_INSUFFICIENT_MEMORY;
     }
@@ -358,14 +362,14 @@ void network_info_cleanup(uint8_t slot) {
     if (slot == MAX_DYNAMIC_NETWORKS) {
         // Cleanup all slots
         for (slot = 0; slot < MAX_DYNAMIC_NETWORKS; slot++) {
-            mem_buffer_cleanup((void **) &(g_icon_bitmap[slot]));
-            mem_buffer_cleanup((void **) &(DYNAMIC_NETWORK_INFO[slot]));
+            mem_buffer_cleanup_impl((void **) &(g_icon_bitmap[slot]), NULL, 0);
+            mem_buffer_cleanup_impl((void **) &(DYNAMIC_NETWORK_INFO[slot]), NULL, 0);
         }
     } else {
         // Cleanup only the specified slot
-        mem_buffer_cleanup((void **) &(g_icon_bitmap[slot]));
-        mem_buffer_cleanup((void **) &(DYNAMIC_NETWORK_INFO[slot]));
+        mem_buffer_cleanup_impl((void **) &(g_icon_bitmap[slot]), NULL, 0);
+        mem_buffer_cleanup_impl((void **) &(DYNAMIC_NETWORK_INFO[slot]), NULL, 0);
     }
     // Free the icon hash if it was allocated
-    mem_buffer_cleanup((void **) &g_network_icon_hash);
+    mem_buffer_cleanup_impl((void **) &g_network_icon_hash, NULL, 0);
 }

--- a/src_features/provide_network_info/network_info.c
+++ b/src_features/provide_network_info/network_info.c
@@ -270,10 +270,8 @@ bool verify_network_info_struct(const s_network_info_ctx *context) {
 
     // Free if already allocated, and reallocate the new size
     // Do not track the allocation in logs, because this buffer is expected to stay allocated
-    if (mem_buffer_allocate_impl((void **) &(DYNAMIC_NETWORK_INFO[g_current_network_slot]),
-                                 sizeof(network_info_t),
-                                 NULL,
-                                 0) == false) {
+    if (mem_buffer_persistent((void **) &(DYNAMIC_NETWORK_INFO[g_current_network_slot]),
+                              sizeof(network_info_t)) == false) {
         PRINTF("Memory allocation failed for icon hash\n");
         return false;
     }

--- a/src_features/provide_network_info/network_info.c
+++ b/src_features/provide_network_info/network_info.c
@@ -269,8 +269,11 @@ bool verify_network_info_struct(const s_network_info_ctx *context) {
     }
 
     // Free if already allocated, and reallocate the new size
-    if (mem_buffer_allocate((void **) &(DYNAMIC_NETWORK_INFO[g_current_network_slot]),
-                            sizeof(network_info_t)) == false) {
+    // Do not track the allocation in logs, because this buffer is expected to stay allocated
+    if (mem_buffer_allocate_impl((void **) &(DYNAMIC_NETWORK_INFO[g_current_network_slot]),
+                                 sizeof(network_info_t),
+                                 NULL,
+                                 0) == false) {
         PRINTF("Memory allocation failed for icon hash\n");
         return false;
     }

--- a/src_features/provide_trusted_name/trusted_name.c
+++ b/src_features/provide_trusted_name/trusted_name.c
@@ -56,6 +56,11 @@ typedef enum {
 s_trusted_name_info *g_trusted_name_info = NULL;
 char *g_trusted_name = NULL;
 
+void trusted_name_cleanup(void) {
+    mem_buffer_cleanup((void **) &g_trusted_name);
+    mem_buffer_cleanup((void **) &g_trusted_name_info);
+}
+
 static bool matching_type(e_name_type type, uint8_t type_count, const e_name_type *types) {
     for (int i = 0; i < type_count; ++i) {
         if (type == types[i]) return true;

--- a/src_features/provide_trusted_name/trusted_name.h
+++ b/src_features/provide_trusted_name/trusted_name.h
@@ -66,3 +66,4 @@ extern char *g_trusted_name;
 
 bool handle_trusted_name_struct(const s_tlv_data *data, s_trusted_name_ctx *context);
 bool verify_trusted_name_struct(const s_trusted_name_ctx *ctx);
+void trusted_name_cleanup(void);

--- a/src_features/signTx/cmd_signTx.c
+++ b/src_features/signTx/cmd_signTx.c
@@ -169,6 +169,9 @@ uint16_t handleSign(uint8_t p1,
         }
     }
     if (sw != APDU_NO_RESPONSE) {
+        if ((sw != APDU_RESPONSE_OK) && (g_tx_hash_ctx != NULL)) {
+            mem_buffer_cleanup((void **) &g_tx_hash_ctx);
+        }
         return sw;
     }
 

--- a/src_nbgl/ui_gcs.c
+++ b/src_nbgl/ui_gcs.c
@@ -12,6 +12,7 @@
 #include "ui_utils.h"
 #include "enum_value.h"
 #include "proxy_info.h"
+#include "trusted_name.h"
 
 static void review_choice(bool confirm) {
     if (confirm) {
@@ -226,8 +227,7 @@ static bool prepare_infos(nbgl_contentInfoList_t *infos) {
 }
 
 void ui_gcs_cleanup(void) {
-    mem_buffer_cleanup((void **) &g_trusted_name);
-    mem_buffer_cleanup((void **) &g_trusted_name_info);
+    trusted_name_cleanup();
     if ((g_pairsList != NULL) && (g_pairsList->pairs != NULL)) {
         for (int i = 0; i < g_pairsList->nbPairs; ++i) {
             free_pair(g_pairsList, i);

--- a/src_nbgl/ui_message_signing.c
+++ b/src_nbgl/ui_message_signing.c
@@ -1,7 +1,10 @@
 #include "ui_nbgl.h"
 #include "ui_logic.h"
 #include "common_712.h"
+#include "common_ui.h"
 #include "ui_utils.h"
+#include "trusted_name.h"
+#include "proxy_info.h"
 
 static void ui_typed_message_review_choice_common(bool confirm,
                                                   nbgl_callback_t approve_func,
@@ -14,6 +17,8 @@ static void ui_typed_message_review_choice_common(bool confirm,
         nbgl_useCaseReviewStatus(STATUS_TYPE_MESSAGE_REJECTED, ui_idle);
     }
     ui_all_cleanup();
+    trusted_name_cleanup();
+    proxy_cleanup();
 }
 
 void ui_typed_message_review_choice_v0(bool confirm) {

--- a/tools/valground.py
+++ b/tools/valground.py
@@ -3,9 +3,31 @@
 # pytest --device nanosp -s -k my_special_test 2>&1 | ./valground.py
 
 import sys
+from argparse import ArgumentParser, Namespace, ArgumentDefaultsHelpFormatter, RawDescriptionHelpFormatter
 from typing import Optional
 
 
+# ===============================================================================
+#          Summary class
+# ===============================================================================
+class GlobalSummary:
+    max_size: int
+    code_location: str
+
+    def __init__(self):
+        self.max_size = 0
+
+    def update(self, size: int):
+        self.max_size = max(size, self.max_size)
+
+    def summary(self):
+        print(f"\n{COLORS['fg_red']}{COLORS['bg_white']}=== Global ==={COLORS['all_reset']}")
+        print(f"{COLORS['fg_yellow']}Higher Max overtime = {self.max_size} bytes{COLORS['all_reset']}\n")
+
+
+# ===============================================================================
+#          Allocation class
+# ===============================================================================
 class Allocation:
     size: int
     code_location: str
@@ -15,6 +37,9 @@ class Allocation:
         self.code_location = code_location
 
 
+# ===============================================================================
+#          Memory class
+# ===============================================================================
 class Memory:
     allocs: dict[Allocation]
     allocd_overtime: int
@@ -23,8 +48,10 @@ class Memory:
     alloc_count: int
     addr: int
     size: int
+    test_name: str
+    free_errors: list[str]
 
-    def __init__(self, addr: int, size: int):
+    def __init__(self, addr: int, size: int, test_name: str) -> None:
         self.allocs = {}
         self.allocd_overtime = 0
         self.allocd_max = 0
@@ -32,59 +59,184 @@ class Memory:
         self.alloc_count = 0
         self.addr = addr
         self.size = size
+        self.test_name = test_name
+        self.free_errors = []
 
-    def alloc(self, ptr: int, size: int, code_loc: str):
+    def alloc(self, ptr: int, size: int, code_loc: str) -> None:
         self.allocs[ptr] = Allocation(size, code_loc)
         self.allocd_current += size
-        if self.allocd_current > self.allocd_max:
-            self.allocd_max = self.allocd_current
+        self.allocd_max = max(self.allocd_max, self.allocd_current)
         self.allocd_overtime += size
         self.alloc_count += 1
 
-    def free(self, ptr: int, code_loc: str):
-        assert ptr in self.allocs
+    def free(self, ptr: int, code_loc: str) -> None:
+        if ptr not in self.allocs:
+            self.free_errors.append(code_loc)
+            return
         self.allocd_current -= self.allocs[ptr].size
         del self.allocs[ptr]
 
-    def __del__(self):
-        if len(self.allocs) == 0:
-            print("No memory leak detected, congrats!")
+    def summary(self, quiet: bool = False) -> bool:
+        print("")
+        if self.test_name:
+            print(f"{COLORS['fg_blue']}{COLORS['bg_white']}{self.test_name}{COLORS['all_reset']}")
+
+        if len(self.free_errors) == 0:
+            if not quiet:
+                print(f"{COLORS['fg_green']}No memory free errors detected, congrats!{COLORS['all_reset']}")
         else:
-            print("Memory leaks :")
+            print(f"{COLORS['fg_red']}Free without malloc, or double free detected:")
+            for code_loc in self.free_errors:
+                print(f"- {code_loc}")
+            print(f"{COLORS['all_reset']}", end='')
+
+        if len(self.allocs) == 0:
+            if not quiet:
+                print(f"{COLORS['fg_green']}No memory leak detected, congrats!{COLORS['all_reset']}")
+        else:
+            print(f"{COLORS['fg_red']}Memory leaks:")
             for addr, info in self.allocs.items():
                 print("- [0x%.08x] %u bytes from %s" % (addr,
                                                         info.size,
                                                         info.code_location))
+            print(f"{COLORS['all_reset']}", end='')
 
-        print("\n=== Summary ===")
-        print("Total overtime = %u bytes" % (self.allocd_overtime))
-        used_percentage = self.allocd_max / self.size * 100
-        print("Max overtime = %u bytes (%.02f%% full)" % (self.allocd_max,
-                                                          used_percentage))
-        print("Allocations = %u" % (self.alloc_count))
+        global_summary.update(self.allocd_max)
+        if not quiet:
+            print("=== Summary ===")
+            print("Total overtime = %u bytes" % (self.allocd_overtime))
+            used_percentage = self.allocd_max / self.size * 100
+            info_str = f"Max overtime = {self.allocd_max} bytes ({used_percentage:.02f}% full)"
+            if used_percentage > 90:
+                print(f"{COLORS['fg_yellow']}{info_str}{COLORS['all_reset']}")
+            else:
+                print(info_str)
+            print("Allocations = %u" % (self.alloc_count))
+
+        return len(self.allocs) + len(self.free_errors) == 0
 
 
-mem: Optional[Memory] = None
+# ===============================================================================
+#          Init colors
+# ===============================================================================
+def init_colors(enable_colors: bool) -> dict[str, str]:
+    """Initialize color variables based on colorama availability
 
-for line in sys.stdin:
-    line = line.rstrip()
-    scheme = "seproxyhal: printf: "
-    if line.startswith(scheme):
-        line = line[len(scheme):]
-        scheme = "==MP "
+    ARGS:
+        enable_colors (bool): Flag to enable or disable colors
+    """
+    colors = {
+        'fg_green': '',
+        'fg_red': '',
+        'all_reset': '',
+        'fg_yellow': '',
+        'fg_blue': '',
+        'bg_white': ''
+    }
+
+    if enable_colors:
+        try:
+            import colorama
+            colorama.init()  # Initialize colorama
+            colors.update({
+                'fg_green': colorama.Fore.GREEN,
+                'fg_red': colorama.Fore.RED,
+                'all_reset': colorama.Fore.RESET + colorama.Back.RESET,
+                'fg_yellow': colorama.Fore.YELLOW,
+                'fg_blue': colorama.Fore.BLUE,
+                'bg_white': colorama.Back.WHITE
+            })
+        except ImportError:
+            print("To use colors, please install colorama: pip install colorama")
+
+    return colors
+
+
+# ===============================================================================
+#          Parameters
+# ===============================================================================
+class CustomFormatter(ArgumentDefaultsHelpFormatter, RawDescriptionHelpFormatter):
+    """Custom formatter that combines ArgumentDefaultsHelpFormatter and RawDescriptionHelpFormatter"""
+    pass
+
+def init_parser() -> Namespace:
+    """Initialize the argument parser for command line arguments"""
+    epilog = "Compile the app with MEMORY_PROFILING=1 and feed the speculos output to this script.\n"
+    epilog += "Example usage: pytest --device nanosp -s -k my_special_test 2>&1 | ./valground.py"
+    parser = ArgumentParser(description="Analyze memory allocations to determine leaks.",
+                            formatter_class=CustomFormatter,
+                            epilog=epilog)
+    parser.add_argument("--quiet", "-q", action='store_true', help="Quiet logs to minimum.")
+    parser.add_argument("--colors", "-c", action='store_true', help="Enable colored output.")
+    return parser.parse_args()
+
+
+# ===============================================================================
+#          Main entry
+# ===============================================================================
+def main() -> None:
+    mem: Optional[Memory] = None
+
+    # Arguments parsing
+    # -----------------
+    args = init_parser()
+
+    # Initialize colors once at module level
+    global COLORS
+    COLORS = init_colors(args.colors)
+
+   # Processing
+    # ----------
+    ret_code = 0
+    testnb = 0
+    test_name = ""
+    for line in sys.stdin:
+        line = line.rstrip()
+
+        # Only print lines that look like pytest test names
+        if line.startswith("collecting"):
+            line = line.replace("collecting ... ", "")
+        if line.startswith("collected"):
+            print(line)
+            nb_tests = int(line.split(" ")[-2])
+            continue
+        if "test_" in line and "::" in line and "[" in line:
+            testnb += 1
+            test_name = f"[{testnb}/{nb_tests}] - {line.split(' ')[0]}"
+            continue
+
+        scheme = "seproxyhal: printf: "
         if line.startswith(scheme):
             line = line[len(scheme):]
-            words = line.split(";")
-            assert len(words) > 2
+            scheme = "==MP "
+            if line.startswith(scheme):
+                line = line[len(scheme):]
+                words = line.split(";")
+                assert len(words) > 2
 
-            if words[0] == "init":
-                mem = Memory(int(words[1], base=0), int(words[2], base=0))
-            elif words[0] == "alloc":
-                mem.alloc(int(words[2], base=0), int(words[1], base=0), words[3])
-            elif words[0] == "free":
-                mem.free(int(words[1], base=0), words[2])
-            else:
-                assert False
+                if words[0] == "init":
+                    # Print summary of previous test if exists
+                    if mem is not None:
+                        if mem.summary(args.quiet) is False:
+                            ret_code = 1
+                    mem = Memory(int(words[1], base=0), int(words[2], base=0), test_name)
+                elif words[0] == "alloc":
+                    mem.alloc(int(words[2], base=0), int(words[1], base=0), words[3])
+                elif words[0] == "free":
+                    mem.free(int(words[1], base=0), words[2])
+                else:
+                    assert False
 
-if mem is None:
-    print("No memory profiling was found.")
+    if mem is None:
+        print(f"{COLORS['fg_red']}No memory profiling was found.{COLORS['all_reset']}")
+    else:
+        if mem.summary(args.quiet) is False:
+            ret_code = 1
+        global_summary.summary()
+    sys.exit(ret_code)
+
+
+global_summary = GlobalSummary()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Add logic to track missing allocation/free utility functions
- Fix few remaining memory leaks
- And adapt `valground` script
  - Add `-q/--quiet` option to limit the logs (hence, only print the memory leaks)
  - Add a the global Higer Max Overtime, corresponding to the max needed allocated memory over all run tests
- Add workflow test (based on ragger) to check the memory leaks