### PR TITLE
Fix decompression of compressed calldata chunks with size 0

### DIFF
--- a/src_features/generic_tx_parser/calldata.c
+++ b/src_features/generic_tx_parser/calldata.c
@@ -92,6 +92,7 @@ static bool decompress_chunk(const s_calldata_chunk *chunk, uint8_t *out) {
     }
     if ((chunk->buf == NULL) || (chunk->size == 0)) {
         // nothing to decompress
+        explicit_bzero(out, CALLDATA_CHUNK_SIZE);
         return true;
     }
     diff = CALLDATA_CHUNK_SIZE - chunk->size;


### PR DESCRIPTION
## Description

Would return a garbage/uninitialized chunk.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)