### PR TITLE
Fixed GCS TX context pop

### DIFF
--- a/src/features/generic_tx_parser/tx_ctx.c
+++ b/src/features/generic_tx_parser/tx_ctx.c
@@ -86,9 +86,12 @@ void tx_ctx_pop(void) {
             break;
         }
     }
+    if (g_tx_ctx_current == (s_tx_ctx *) old_current) {
+        // there was no previous one
+        // there might still be some elements in the list but after the one that we're removing
+        g_tx_ctx_current = NULL;
+    }
     flist_remove((s_flist_node **) &g_tx_ctx_list, old_current, (f_list_node_del) &delete_tx_ctx);
-    // set proper current pointer when list becomes empty
-    if (g_tx_ctx_list == NULL) g_tx_ctx_current = NULL;
 }
 
 bool find_matching_tx_ctx(const uint8_t *contract_addr,


### PR DESCRIPTION
## Description

Could create an infinite loop with dangling pointers.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)