### PR TITLE
Fix STRUCT_TYPE value 0x0A for Safe Signers

### DIFF
--- a/client/src/ledger_app_clients/ethereum/safe.py
+++ b/client/src/ledger_app_clients/ethereum/safe.py
@@ -54,7 +54,8 @@ class SafeAccount(TlvSerializable):
             assert self.signer_counts > 0, "Signer counts must be greater than 0"
             assert self.lesm_role is not None, "LESM role is required for SAFE accounts"
         # Construct the TLV payload
-        payload: bytes = self.serialize_field(FieldTag.STRUCT_TYPE, 0x27)
+        struct_type = 0x27 if self.account_type == AccountType.SAFE else 0x0A
+        payload: bytes = self.serialize_field(FieldTag.STRUCT_TYPE, struct_type)
         payload += self.serialize_field(FieldTag.STRUCT_VERSION, 1)
         payload += self.serialize_field(FieldTag.CHALLENGE, self.challenge)
         for addr in self.address:

--- a/src/features/provide_safe_account/signer_descriptor.c
+++ b/src/features/provide_safe_account/signer_descriptor.c
@@ -16,7 +16,7 @@
 #include "read.h"
 #include "mem.h"
 
-#define TYPE_VERIFIABLE_ADDRESS 0x27
+#define TYPE_VERIFIABLE_ADDRESS 0x0A
 #define STRUCT_VERSION          0x01
 
 enum {


### PR DESCRIPTION
## Description

Bad copy-paste value fix

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
