### PR TITLE
remove make shell command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ ifeq ($(TARGET_NAME),$(filter $(TARGET_NAME),TARGET_STAX TARGET_FLEX TARGET_APEX
     NETWORK_ICONS_DIR = $(shell dirname "$(NETWORK_ICONS_FILE)")
 
     $(NETWORK_ICONS_FILE):
-    	$(shell python3 tools/gen_networks.py "$(NETWORK_ICONS_DIR)")
+		python3 tools/gen_networks.py "$(NETWORK_ICONS_DIR)"
 
     APP_SOURCE_FILES += $(NETWORK_ICONS_FILE)
 endif


### PR DESCRIPTION
## Description

This PR fixes a small issue, that led to rebuilding `net_icons.o` and `network_icons.o` every time in incremental builds :

```
make: Entering directory '/app'
Prepare directories
[CC]   build/stax/gen_src/net_icons.gen.o
[CC]   build/stax/obj/app/src/nbgl/network_icons.o
[LINK] build/stax/bin/app.elf
[CP] build/stax/bin/app.elf => bin/app.elf
[CP] build/stax/bin/app.hex => bin/app.hex
[CP] build/stax/dbg/app.map => debug/app.map
[CP] build/stax/dbg/app.asm => debug/app.asm
[CP] build/stax/bin/app.apdu => bin/app.apdu
[CP] build/stax/bin/app.sha256 => bin/app.sha256
make: Leaving directory '/app'
```

The reason is because of the GNU Make `shell` function invocation, which evaluates during make's evaluation pass that expands commands.

Simply Removing invocation to `shell` leads to the desired behavior :

```
make: Entering directory '/app'
Building with 'dbg_use_test_keys' configuration...
Prepare directories
[CP] build/flex/bin/app.elf => bin/app.elf
[CP] build/flex/bin/app.hex => bin/app.hex
[CP] build/flex/dbg/app.map => debug/app.map
[CP] build/flex/dbg/app.asm => debug/app.asm
[CP] build/flex/bin/app.apdu => bin/app.apdu
[CP] build/flex/bin/app.sha256 => bin/app.sha256
make: Leaving directory '/app'
 *  Terminal will be reused by tasks, press any key to close it.
```

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
