### PR TITLE
fix: Out-of-bounds read on zero-length int8 EIP-712 fields during display formatting

### DIFF
--- a/src/features/sign_message_eip712/ui_logic.c
+++ b/src/features/sign_message_eip712/ui_logic.c
@@ -477,6 +477,10 @@ static bool ui_712_format_int(const uint8_t *data,
     if (!first) {
         return false;
     }
+    if (length < 1) {
+        apdu_response_code = SWO_INCORRECT_DATA;
+        return false;
+    }
     if (length > field_ptr->type_size) {
         apdu_response_code = SWO_INCORRECT_DATA;
         return false;
@@ -506,6 +510,10 @@ static bool ui_712_format_int(const uint8_t *data,
             snprintf(strings.tmp.tmp, sizeof(strings.tmp.tmp), "%d", value16);
             break;
         case 8:
+            if (length != sizeof(int8_t)) {
+                apdu_response_code = SWO_INCORRECT_DATA;
+                return false;
+            }
             value8 = (int8_t) data[0];
             snprintf(strings.tmp.tmp, sizeof(strings.tmp.tmp), "%d", value8);
             break;


### PR DESCRIPTION
## Summary

Automated security fix for **Out-of-bounds read on zero-length int8 EIP-712 fields during display formatting** (High).

**CWE**: CWE-CWE-125
**OWASP**: A03:2021-Injection
**Fix Confidence**: high

## What Changed
Added strict length validation for signed integer display formatting in ui_712_format_int(). Zero-length signed integers are now rejected before any formatting work, and the int8 branch now requires exactly one byte before dereferencing data[0], eliminating the out-of-bounds read.

## Caveats
- This fix hardens the UI formatting path directly; it does not add an earlier rejection in field_hash.c, though malformed zero-length signed integers are now rejected before any display formatting occurs.

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
