### PR TITLE
fix: Blind-signing gate is bypassed for single-byte calldata 0x00 transactions

### DIFF
--- a/src/features/sign_tx/eth_ustream.c
+++ b/src/features/sign_tx/eth_ustream.c
@@ -315,10 +315,6 @@ static bool process_data(txContext_t *context) {
     if (context->currentFieldPos < context->currentFieldLength) {
         uint32_t copySize =
             MIN(context->commandLength, context->currentFieldLength - context->currentFieldPos);
-        // If there is no data, set dataPresent to false.
-        if (copySize == 1 && *context->workBuffer == 0x00) {
-            context->content->dataPresent = false;
-        }
 
         if ((context->currentFieldPos == 0) && (copySize >= 4)) {
             // Consider the 4 1st bytes are the selector


### PR DESCRIPTION
## Summary

Automated security fix for **Blind-signing gate is bypassed for single-byte calldata 0x00 transactions** (High).

**CWE**: CWE-CWE-285
**OWASP**: A01:2021-Broken Access Control
**Fix Confidence**: high

## What Changed
Removed the special-case in process_data() that treated a single-byte calldata payload of 0x00 as if no calldata were present. Non-empty calldata now preserves the dataPresent state set earlier by custom_processor(), so blind-signing checks still apply for 0x00 calldata while true zero-length data fields remain unaffected.

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
