### PR TITLE
fix: Out-of-bounds read in amount-join token address comparison in update_amount_join

### DIFF
--- a/src/features/sign_message_eip712/ui_logic.c
+++ b/src/features/sign_message_eip712/ui_logic.c
@@ -638,6 +638,10 @@ static bool update_amount_join(const uint8_t *data, uint8_t length) {
     }
     switch (ui_ctx->amount.state) {
         case AMOUNT_JOIN_STATE_TOKEN:
+            if (length != ADDRESS_LENGTH) {
+                apdu_response_code = SWO_INCORRECT_DATA;
+                return false;
+            }
             if (token != NULL) {
                 if (memcmp(data, token->address, ADDRESS_LENGTH) != 0) {
                     return false;


### PR DESCRIPTION
## Summary

Automated security fix for **Out-of-bounds read in amount-join token address comparison in update_amount_join** (High).

**CWE**: CWE-CWE-125
**OWASP**: A04:2021-Insecure Design
**Fix Confidence**: high

## What Changed
Added a fixed-width length check in the amount-join token path before comparing against the 20-byte token address. This prevents `memcmp` from reading past a short attacker-controlled field buffer while preserving existing behavior for valid address fields.

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
