### PR TITLE
Fuzzing workaround

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools:latest AS app-builder
+FROM ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest AS app-builder
 
 # Base image with clang toolchain
 FROM gcr.io/oss-fuzz-base/base-builder:v1

--- a/src/common_ui.h
+++ b/src/common_ui.h
@@ -30,3 +30,6 @@ void ui_sign_7702_auth(void);
 void ui_sign_7702_revocation(void);
 void ui_error_no_7702(void);
 void ui_error_no_7702_whitelist(void);
+
+// Swap
+void ui_swap_show_signing(void);

--- a/src/features/provide_gating/cmd_get_gating.c
+++ b/src/features/provide_gating/cmd_get_gating.c
@@ -26,7 +26,6 @@
 #include "tlv_apdu.h"
 #include "tlv_utils.h"
 #include "utils.h"
-#include "nbgl_use_case.h"
 #include "os_pki.h"
 #include "network.h"
 #include "ui_callbacks.h"

--- a/src/features/provide_tx_simulation/cmd_get_tx_simulation.c
+++ b/src/features/provide_tx_simulation/cmd_get_tx_simulation.c
@@ -9,7 +9,6 @@
 #include "tlv_apdu.h"
 #include "tlv_utils.h"
 #include "utils.h"
-#include "nbgl_use_case.h"
 #include "os_pki.h"
 #include "network.h"
 #include "ui_callbacks.h"

--- a/src/nbgl/ui_approve_tx.c
+++ b/src/nbgl/ui_approve_tx.c
@@ -47,10 +47,14 @@ static void _cleanup(void) {
 static void reviewChoice(bool confirm) {
     if (confirm) {
         io_seproxyhal_touch_tx_ok();
+#ifndef FUZZ
         nbgl_useCaseReviewStatus(STATUS_TYPE_TRANSACTION_SIGNED, ui_idle);
+#endif
     } else {
         io_seproxyhal_touch_tx_cancel();
+#ifndef FUZZ
         nbgl_useCaseReviewStatus(STATUS_TYPE_TRANSACTION_REJECTED, ui_idle);
+#endif
     }
     _cleanup();
 }
@@ -417,6 +421,7 @@ uint16_t ux_approve_tx(bool fromPlugin) {
         return sw;
     }
 
+#ifndef FUZZ
     nbgl_useCaseAdvancedReview(TYPE_TRANSACTION,
                                g_pairsList,
                                get_tx_icon(fromPlugin),
@@ -426,5 +431,6 @@ uint16_t ux_approve_tx(bool fromPlugin) {
                                NULL,
                                &warning,
                                reviewChoice);
+#endif
     return SWO_SUCCESS;
 }

--- a/src/nbgl/ui_blind_signing.c
+++ b/src/nbgl/ui_blind_signing.c
@@ -11,6 +11,7 @@ static void ui_error_blind_signing_choice(bool confirm) {
 #endif
 
 void ui_error_blind_signing(void) {
+#ifndef FUZZ
 #ifdef SCREEN_SIZE_WALLET
     nbgl_useCaseChoice(&ICON_APP_WARNING,
                        "This transaction cannot be clear-signed",
@@ -23,5 +24,6 @@ void ui_error_blind_signing(void) {
                        "Blind signing must\nbe enabled in\nsettings",
                        NULL,
                        ui_idle);
+#endif
 #endif
 }

--- a/src/nbgl/ui_confirm_parameter_selector.c
+++ b/src/nbgl/ui_confirm_parameter_selector.c
@@ -46,6 +46,7 @@ static void buildScreen(e_confirmation_type confirm_type) {
     if (tmpContent.txContent.dataPresent) {
         op |= BLIND_OPERATION;
     }
+#ifndef FUZZ
     nbgl_useCaseReview(op,
                        g_pairsList,
                        get_tx_icon(false),
@@ -53,6 +54,7 @@ static void buildScreen(e_confirmation_type confirm_type) {
                        NULL,
                        g_finishMsg,
                        reviewChoice);
+#endif
 }
 
 void ui_confirm_parameter(void) {

--- a/src/nbgl/ui_display_privacy.c
+++ b/src/nbgl/ui_display_privacy.c
@@ -23,6 +23,7 @@ static void buildFirstPage(const char *review_string) {
     g_pairs[1].item = "Key";
     g_pairs[1].value = strings.common.fullAmount;
 
+#ifndef FUZZ
     nbgl_useCaseReview(TYPE_OPERATION,
                        g_pairsList,
                        get_tx_icon(false),
@@ -30,6 +31,7 @@ static void buildFirstPage(const char *review_string) {
                        NULL,
                        review_string,
                        reviewChoice);
+#endif
 }
 
 void ui_display_privacy_public_key(void) {

--- a/src/nbgl/ui_gcs.c
+++ b/src/nbgl/ui_gcs.c
@@ -21,10 +21,14 @@ static bool *index_allocated = NULL;
 static void review_choice(bool confirm) {
     if (confirm) {
         io_seproxyhal_touch_tx_ok();
+#ifndef FUZZ
         nbgl_useCaseReviewStatus(STATUS_TYPE_TRANSACTION_SIGNED, ui_idle);
+#endif
     } else {
         io_seproxyhal_touch_tx_cancel();
+#ifndef FUZZ
         nbgl_useCaseReviewStatus(STATUS_TYPE_TRANSACTION_REJECTED, ui_idle);
+#endif
     }
 }
 
@@ -541,6 +545,7 @@ bool ui_gcs(void) {
     g_pairs[pair].value = APP_MEM_STRDUP(tmp_buf);
     index_allocated[pair] = true;
 
+#ifndef FUZZ
     nbgl_useCaseAdvancedReview(TYPE_TRANSACTION,
                                g_pairsList,
                                get_tx_icon(false),
@@ -550,5 +555,6 @@ bool ui_gcs(void) {
                                NULL,
                                &warning,
                                review_choice);
+#endif
     return true;
 }

--- a/src/nbgl/ui_get_eth2_public_key.c
+++ b/src/nbgl/ui_get_eth2_public_key.c
@@ -10,10 +10,14 @@
 static void reviewChoice(bool confirm) {
     if (confirm) {
         io_seproxyhal_touch_address_ok();
+#ifndef FUZZ
         nbgl_useCaseReviewStatus(STATUS_TYPE_ADDRESS_VERIFIED, ui_idle);
+#endif
     } else {
         io_seproxyhal_touch_address_cancel();
+#ifndef FUZZ
         nbgl_useCaseReviewStatus(STATUS_TYPE_ADDRESS_REJECTED, ui_idle);
+#endif
     }
     ui_buffers_cleanup();
 }
@@ -37,10 +41,12 @@ void ui_display_public_eth2(void) {
                        tmpCtx.publicKeyContext.publicKey.W,
                        BLS12381_G1_COMPRESSED_PUBKEY_LENGTH);
 
+#ifndef FUZZ
     nbgl_useCaseAddressReview(g_subTitleMsg,
                               NULL,
                               get_app_icon(false),
                               g_titleMsg,
                               NULL,
                               reviewChoice);
+#endif
 }

--- a/src/nbgl/ui_get_public_key.c
+++ b/src/nbgl/ui_get_public_key.c
@@ -9,10 +9,14 @@
 static void review_choice(bool confirm) {
     if (confirm) {
         io_seproxyhal_touch_address_ok();
+#ifndef FUZZ
         nbgl_useCaseReviewStatus(STATUS_TYPE_ADDRESS_VERIFIED, ui_idle);
+#endif
     } else {
         io_seproxyhal_touch_address_cancel();
+#ifndef FUZZ
         nbgl_useCaseReviewStatus(STATUS_TYPE_ADDRESS_REJECTED, ui_idle);
+#endif
     }
     ui_buffers_cleanup();
 }
@@ -61,10 +65,12 @@ void ui_display_public_key(const uint64_t *chain_id) {
     } else {
         icon = get_app_icon(false);
     }
+#ifndef FUZZ
     nbgl_useCaseAddressReview(strings.common.toAddress,
                               NULL,
                               icon,
                               g_titleMsg,
                               NULL,
                               review_choice);
+#endif
 }

--- a/src/nbgl/ui_home.c
+++ b/src/nbgl/ui_home.c
@@ -192,6 +192,7 @@ static void prepare_and_display_home(const char *appname, const char *tagline, u
     infoList.infoTypes = infoTypes;
     infoList.infoContents = infoContents;
 
+#ifndef FUZZ
     nbgl_useCaseHomeAndSettings(appname,
                                 get_home_icon(),
                                 tagline,
@@ -200,6 +201,7 @@ static void prepare_and_display_home(const char *appname, const char *tagline, u
                                 &infoList,
                                 NULL,
                                 app_quit);
+#endif
 }
 
 /**

--- a/src/nbgl/ui_message_signing.c
+++ b/src/nbgl/ui_message_signing.c
@@ -11,10 +11,14 @@ static void ui_typed_message_review_choice_common(bool confirm,
                                                   nbgl_callback_t reject_func) {
     if (confirm) {
         approve_func();
+#ifndef FUZZ
         nbgl_useCaseReviewStatus(STATUS_TYPE_MESSAGE_SIGNED, ui_idle);
+#endif
     } else {
         reject_func();
+#ifndef FUZZ
         nbgl_useCaseReviewStatus(STATUS_TYPE_MESSAGE_REJECTED, ui_idle);
+#endif
     }
     ui_all_cleanup();
     proxy_cleanup();

--- a/src/nbgl/ui_no_7702.c
+++ b/src/nbgl/ui_no_7702.c
@@ -12,6 +12,7 @@ static void ui_error_no_7702_choice(bool confirm) {
 }
 
 void ui_error_no_7702(void) {
+#ifndef FUZZ
     nbgl_useCaseChoice(&ICON_APP_WARNING,
 #ifdef SCREEN_SIZE_WALLET
                        "This authorization cannot be signed",
@@ -22,4 +23,5 @@ void ui_error_no_7702(void) {
                        "Go to settings",
                        "Reject authorization",
                        ui_error_no_7702_choice);
+#endif
 }

--- a/src/nbgl/ui_no_7702_whitelist.c
+++ b/src/nbgl/ui_no_7702_whitelist.c
@@ -9,6 +9,7 @@ static void ui_error_no_7702_whitelist_choice(bool confirm) {
 }
 
 void ui_error_no_7702_whitelist(void) {
+#ifndef FUZZ
     nbgl_useCaseChoice(&ICON_APP_WARNING,
 #ifdef SCREEN_SIZE_WALLET
                        "This authorization cannot be signed",
@@ -20,4 +21,5 @@ void ui_error_no_7702_whitelist(void) {
                        "Back to safety",
                        "",
                        ui_error_no_7702_whitelist_choice);
+#endif
 }

--- a/src/nbgl/ui_safe_account.c
+++ b/src/nbgl/ui_safe_account.c
@@ -176,12 +176,16 @@ static void review_cb(bool confirm) {
     if (confirm) {
         // User confirmed the Safe Account
         _cleanup(SWO_SUCCESS);
+#ifndef FUZZ
         nbgl_useCaseStatus("Safe Address validated", true, ui_idle);
+#endif
         return;
     } else {
         // User rejected the Safe Account
         _cleanup(SWO_CONDITIONS_NOT_SATISFIED);
+#ifndef FUZZ
         nbgl_useCaseStatus("Safe Address rejected", false, ui_idle);
+#endif
     }
 }
 
@@ -202,10 +206,12 @@ void ui_display_safe_account(void) {
     // Setup data to display
     setTagValuePairs();
 
+#ifndef FUZZ
     nbgl_useCaseAddressReview(strings.tmp.tmp,
                               g_pairsList,
                               &ICON_APP_MULTISIG,
                               "Verify Safe address",
                               NULL,
                               review_cb);
+#endif
 }

--- a/src/nbgl/ui_sign_712.c
+++ b/src/nbgl/ui_sign_712.c
@@ -53,6 +53,7 @@ static void ui_712_start_review(e_eip712_filtering_mode filtering_mode,
         }
     }
 
+#ifndef FUZZ
     nbgl_useCaseAdvancedReview(operationType,
                                g_pairsList,
                                &ICON_APP_REVIEW,
@@ -62,6 +63,7 @@ static void ui_712_start_review(e_eip712_filtering_mode filtering_mode,
                                NULL,
                                &warning,
                                choiceCallback);
+#endif
 }
 
 /**

--- a/src/nbgl/ui_sign_authorization_7702.c
+++ b/src/nbgl/ui_sign_authorization_7702.c
@@ -9,10 +9,14 @@
 static void review7702Choice(bool confirm) {
     if (confirm) {
         auth_7702_ok_cb();
+#ifndef FUZZ
         nbgl_useCaseReviewStatus(STATUS_TYPE_OPERATION_SIGNED, ui_idle);
+#endif
     } else {
         auth_7702_cancel_cb();
+#ifndef FUZZ
         nbgl_useCaseReviewStatus(STATUS_TYPE_OPERATION_REJECTED, ui_idle);
+#endif
     }
     ui_pairs_cleanup();
 }
@@ -35,6 +39,7 @@ void ui_sign_7702_auth(void) {
 #endif
     g_pairs[2].value = strings.common.network_name;
 
+#ifndef FUZZ
     nbgl_useCaseReview(TYPE_OPERATION,
                        g_pairsList,
                        &ICON_APP_REVIEW,
@@ -46,4 +51,5 @@ void ui_sign_7702_auth(void) {
                        "Sign operation",
 #endif
                        review7702Choice);
+#endif
 }

--- a/src/nbgl/ui_sign_message.c
+++ b/src/nbgl/ui_sign_message.c
@@ -8,10 +8,14 @@
 static void ui_191_finish_cb(bool confirm) {
     if (confirm) {
         io_seproxyhal_touch_signMessage_ok();
+#ifndef FUZZ
         nbgl_useCaseReviewStatus(STATUS_TYPE_MESSAGE_SIGNED, ui_idle);
+#endif
     } else {
         io_seproxyhal_touch_signMessage_cancel();
+#ifndef FUZZ
         nbgl_useCaseReviewStatus(STATUS_TYPE_MESSAGE_REJECTED, ui_idle);
+#endif
     }
     ui_all_cleanup();
 }
@@ -43,6 +47,7 @@ void ui_191_start(const char *message) {
     g_pairs->item = "Message";
     g_pairs->value = message;
 
+#ifndef FUZZ
     nbgl_useCaseAdvancedReview(TYPE_MESSAGE,
                                g_pairsList,
                                &ICON_APP_REVIEW,
@@ -52,4 +57,5 @@ void ui_191_start(const char *message) {
                                NULL,
                                &warning,
                                ui_191_finish_cb);
+#endif
 }

--- a/src/nbgl/ui_sign_revocation_7702.c
+++ b/src/nbgl/ui_sign_revocation_7702.c
@@ -8,10 +8,14 @@
 static void review7702Choice(bool confirm) {
     if (confirm) {
         auth_7702_ok_cb();
+#ifndef FUZZ
         nbgl_useCaseReviewStatus(STATUS_TYPE_OPERATION_SIGNED, ui_idle);
+#endif
     } else {
         auth_7702_cancel_cb();
+#ifndef FUZZ
         nbgl_useCaseReviewStatus(STATUS_TYPE_OPERATION_REJECTED, ui_idle);
+#endif
     }
     ui_pairs_cleanup();
 }
@@ -28,6 +32,7 @@ void ui_sign_7702_revocation(void) {
     g_pairs[1].item = "Revoke on network";
     g_pairs[1].value = strings.common.network_name;
 
+#ifndef FUZZ
     nbgl_useCaseReview(TYPE_OPERATION,
                        g_pairsList,
                        &ICON_APP_REVIEW,
@@ -39,4 +44,5 @@ void ui_sign_7702_revocation(void) {
                        "Sign operation",
 #endif
                        review7702Choice);
+#endif
 }

--- a/src/nbgl/ui_swap.c
+++ b/src/nbgl/ui_swap.c
@@ -1,0 +1,7 @@
+#include "nbgl_use_case.h"
+
+void ui_swap_show_signing(void) {
+#ifdef SCREEN_SIZE_WALLET
+    nbgl_useCaseSpinner("Signing");
+#endif  // SCREEN_SIZE_WALLET
+}

--- a/src/nbgl/ui_swap.c
+++ b/src/nbgl/ui_swap.c
@@ -2,6 +2,8 @@
 
 void ui_swap_show_signing(void) {
 #ifdef SCREEN_SIZE_WALLET
+#ifndef FUZZ
     nbgl_useCaseSpinner("Signing");
+#endif
 #endif  // SCREEN_SIZE_WALLET
 }

--- a/src/nbgl/ui_tx_simulation.c
+++ b/src/nbgl/ui_tx_simulation.c
@@ -45,7 +45,9 @@ static void ui_tx_simulation_explain(void) {
 
     layoutDescription.withLeftBorder = true;
     layoutDescription.onActionCallback = opt_in_explain_cb;
+#ifndef FUZZ
     layoutCtx = nbgl_layoutGet(&layoutDescription);
+#endif
     const char *rowTexts[HOW_TO_INFO_NB] = {
         "Transaction is checked for threats before signing.",
         "The result is displayed: Critical threat, potential risk or no threat.",
@@ -58,17 +60,21 @@ static void ui_tx_simulation_explain(void) {
     };
 
     // add header
+#ifndef FUZZ
     nbgl_layoutAddHeader(layoutCtx, &headerDesc);
+#endif
 
     // add title
     info.title = "How it works";
     info.nbRows = HOW_TO_INFO_NB;
     info.rowTexts = rowTexts;
     info.rowIcons = rowIcons;
+#ifndef FUZZ
     nbgl_layoutAddLeftContent(layoutCtx, &info);
 
     nbgl_layoutDraw(layoutCtx);
     nbgl_refresh();
+#endif
 }
 
 /**
@@ -79,7 +85,9 @@ static void ui_tx_simulation_explain(void) {
  */
 static void finalise_opt_in(bool confirm, nbgl_callback_t callback) {
     if (confirm) {
+#ifndef FUZZ
         nbgl_useCaseStatus("Transaction Check enabled", true, callback);
+#endif
     } else {
         callback();
     }
@@ -147,10 +155,12 @@ void ui_tx_simulation_opt_in(bool response_expected) {
     g_response_expected = response_expected;
     layoutDescription.withLeftBorder = true;
     layoutDescription.onActionCallback = opt_in_action_cb;
+#ifndef FUZZ
     layoutCtx = nbgl_layoutGet(&layoutDescription);
 
     // add header
     nbgl_layoutAddHeader(layoutCtx, &headerDesc);
+#endif
 
     // add main content
     info.title = "Enable\nTransaction Check?";
@@ -158,16 +168,20 @@ void ui_tx_simulation_opt_in(bool response_expected) {
         "Get real-time warnings about risky Ethereum transactions. "
         "Powered by service providers.";
     info.subText = "By enabling, you accept T&Cs: ledger.com/tx-check";
+#ifndef FUZZ
     nbgl_layoutAddContentCenter(layoutCtx, &info);
 
     // add button and footer on bottom
     nbgl_layoutAddChoiceButtons(layoutCtx, &buttonsInfo);
+#endif
 
 #ifdef HAVE_PIEZO_SOUND
     io_seproxyhal_play_tune(TUNE_LOOK_AT_ME);
 #endif  // HAVE_PIEZO_SOUND
+#ifndef FUZZ
     nbgl_layoutDraw(layoutCtx);
     nbgl_refresh();
+#endif
 }
 
 #endif  // HAVE_TRANSACTION_CHECKS

--- a/src/swap/handle_swap_sign_transaction.c
+++ b/src/swap/handle_swap_sign_transaction.c
@@ -1,9 +1,9 @@
 #include "eth_swap_utils.h"
 #include "shared_context.h"
 #include "cmd_set_plugin.h"
-#include "nbgl_use_case.h"
 #include "app_mem_utils.h"
 #include "mem_utils.h"
+#include "common_ui.h"
 
 // Standard or crosschain swap type
 swap_mode_t G_swap_mode;
@@ -151,9 +151,7 @@ void __attribute__((noreturn)) handle_swap_sign_transaction(const chain_config_t
         set_swap_with_calldata_plugin_type();
     }
 
-#ifdef SCREEN_SIZE_WALLET
-    nbgl_useCaseSpinner("Signing");
-#endif  // SCREEN_SIZE_WALLET
+    ui_swap_show_signing();
 
     app_main();
 

--- a/tests/fuzzing/README.md
+++ b/tests/fuzzing/README.md
@@ -17,18 +17,18 @@ The vulnerable input file created can be passed as an argument to the fuzzer to 
 
 ### Preparation
 
-The fuzzer can be run using the Docker image `ledger-app-dev-tools`. You can download it from the
+The fuzzer can be run using the Docker image `ledger-app-builder-lite`. You can download it from the
 `ghcr.io` docker repository:
 
 ```bash
-docker pull ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools:latest
+docker pull ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest
 ```
 
 You can then enter this development environment by executing the following command from the
 repository root directory:
 
 ```bash
-docker run --rm -ti -v "$(realpath .):/app" ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools:latest
+docker run --rm -ti -v "$(realpath .):/app" ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest
 ```
 
 ### Writing your Harness
@@ -69,7 +69,6 @@ Install the needed modules and set the BOLOS_SDK variable:
 ```bash
 export BOLOS_SDK=/opt/flex-secure-sdk/
 cd tests/fuzzing
-apt update && apt install -y libbsd-dev
 ```
 
 #### Compile the fuzzers


### PR DESCRIPTION
## Description

Workaround because NBGL mocks generation seem to be broken since [API_LEVEL_26](https://github.com/LedgerHQ/ledger-secure-sdk/pull/1255) and the fuzzing was actually going into the real NBGL code.
Far from elegant but fixes the CI in the meantime.
All this preprocessing can be removed once it is fixed on the SDK side.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [x] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)