### PR TITLE
Few cleanup

### DIFF
--- a/src/apdu_constants.h
+++ b/src/apdu_constants.h
@@ -78,7 +78,6 @@
 #define P2_EIP712_LEGACY_IMPLEM 0x00
 #define P2_EIP712_FULL_IMPLEM   0x01
 
-#define APDU_NO_RESPONSE                0x0000
 #define APDU_RESPONSE_MODE_CHECK_FAILED 0x6001
 
 uint16_t handle_get_public_key(uint8_t p1,

--- a/src/features/perform_privacy_operation/cmd_perform_privacy_operation.c
+++ b/src/features/perform_privacy_operation/cmd_perform_privacy_operation.c
@@ -107,7 +107,7 @@ uint16_t handle_perform_privacy_operation(uint8_t p1,
         ui_display_privacy_shared_secret();
     }
     // Return code will be sent after UI approve/cancel
-    error = APDU_NO_RESPONSE;
+    error = SWO_NO_RESPONSE;
 end:
     explicit_bzero(privateKeyDataSwapped, sizeof(privateKeyDataSwapped));
     explicit_bzero(&privateKey, sizeof(privateKey));

--- a/src/features/provide_enum_value/enum_value.c
+++ b/src/features/provide_enum_value/enum_value.c
@@ -21,7 +21,11 @@ static s_enum_value_entry *g_enum_value_list = NULL;
  */
 static bool handle_version(const tlv_data_t *data, s_enum_value_ctx *context) {
     UNUSED(context);
-    return tlv_check_struct_version(data, STRUCT_VERSION);
+    if (!tlv_enforce_u8_value(data, STRUCT_VERSION)) {
+        PRINTF("Invalid STRUCTURE_VERSION value\n");
+        return false;
+    }
+    return true;
 }
 
 /**

--- a/src/features/provide_gating/cmd_get_gating.c
+++ b/src/features/provide_gating/cmd_get_gating.c
@@ -90,7 +90,11 @@ static nbgl_genericDetails_t generic_details = {0};
  */
 static bool parse_struct_type(const tlv_data_t *data, s_gating_ctx *context) {
     UNUSED(context);
-    return tlv_check_struct_type(data, TYPE_GATED_SIGNING);
+    if (!tlv_enforce_u8_value(data, TYPE_GATED_SIGNING)) {
+        PRINTF("Invalid STRUCTURE_TYPE value\n");
+        return false;
+    }
+    return true;
 }
 
 /**
@@ -102,7 +106,11 @@ static bool parse_struct_type(const tlv_data_t *data, s_gating_ctx *context) {
  */
 static bool parse_struct_version(const tlv_data_t *data, s_gating_ctx *context) {
     UNUSED(context);
-    return tlv_check_struct_version(data, STRUCT_VERSION);
+    if (!tlv_enforce_u8_value(data, STRUCT_VERSION)) {
+        PRINTF("Invalid STRUCTURE_VERSION value\n");
+        return false;
+    }
+    return true;
 }
 
 /**

--- a/src/features/provide_gating/cmd_get_gating.c
+++ b/src/features/provide_gating/cmd_get_gating.c
@@ -135,7 +135,7 @@ static bool parse_address(const tlv_data_t *data, s_gating_ctx *context) {
     if (!tlv_get_address(data, (uint8_t *) context->gating->address)) {
         return false;
     }
-    if (allzeroes(context->gating->address, ADDRESS_LENGTH) == 1) {
+    if (is_zeroes_buffer(context->gating->address, ADDRESS_LENGTH)) {
         PRINTF("ADDRESS: all zeroes\n");
         return false;
     }
@@ -344,7 +344,7 @@ static void print_gating_info(s_gating_ctx *context) {
     }
     len = (context->gating->type == TX_TYPE_TRANSACTION) ? SELECTOR_SIZE
                                                          : sizeof(context->gating->hash_selector);
-    if (allzeroes((const void *) context->gating->hash_selector, len) == 0) {
+    if (!is_zeroes_buffer((const void *) context->gating->hash_selector, len)) {
         PRINTF("[GATING] -    Hash Selector: %.*h\n", len, context->gating->hash_selector);
     }
     PRINTF("[GATING] -    Intro Msg: %s\n", context->gating->intro_msg);
@@ -458,7 +458,7 @@ static bool check_gating_address(void) {
     const uint8_t *selector = NULL;
     const uint8_t *contract = NULL;
 
-    if (allzeroes((const void *) GATING->address, ADDRESS_LENGTH)) {
+    if (is_zeroes_buffer((const void *) GATING->address, ADDRESS_LENGTH)) {
         PRINTF("[GATING] TO address missing\n");
         return false;
     }
@@ -552,7 +552,7 @@ static bool check_gating_selector(void) {
     switch (GATING->type) {
         case TX_TYPE_TRANSACTION:
             // Check if the descriptor is set
-            if (allzeroes((const void *) GATING->hash_selector, SELECTOR_SIZE)) {
+            if (is_zeroes_buffer((const void *) GATING->hash_selector, SELECTOR_SIZE)) {
                 break;
             }
             if (memcmp(GATING->hash_selector, txContext.selector_bytes, SELECTOR_SIZE) != 0) {

--- a/src/features/provide_map_entry/map_entry.c
+++ b/src/features/provide_map_entry/map_entry.c
@@ -17,7 +17,11 @@ static s_map_entry *g_map_entry_list = NULL;
 
 static bool handle_version(const tlv_data_t *data, s_map_entry_ctx *context) {
     UNUSED(context);
-    return tlv_check_struct_version(data, STRUCT_VERSION);
+    if (!tlv_enforce_u8_value(data, STRUCT_VERSION)) {
+        PRINTF("Invalid STRUCTURE_VERSION value\n");
+        return false;
+    }
+    return true;
 }
 
 static bool handle_chain_id(const tlv_data_t *data, s_map_entry_ctx *context) {

--- a/src/features/provide_network_info/network_icon.c
+++ b/src/features/provide_network_info/network_icon.c
@@ -211,7 +211,7 @@ uint16_t handle_network_icon_chunks(uint8_t p1, const buffer_t *buf) {
         return SWO_INCORRECT_DATA;
     }
 
-    if ((g_network_icon_hash == NULL) || (allzeroes(g_network_icon_hash, CX_SHA256_SIZE) == 1)) {
+    if ((g_network_icon_hash == NULL) || is_zeroes_buffer(g_network_icon_hash, CX_SHA256_SIZE)) {
         PRINTF("Error: Icon hash not set!\n");
         return SWO_INCORRECT_DATA;
     }

--- a/src/features/provide_network_info/network_info.c
+++ b/src/features/provide_network_info/network_info.c
@@ -41,7 +41,11 @@ network_info_t *g_last_added_network = NULL;
  */
 static bool handle_struct_type(const tlv_data_t *data, s_network_info_ctx *context) {
     UNUSED(context);
-    return tlv_check_struct_type(data, TYPE_DYNAMIC_NETWORK);
+    if (!tlv_enforce_u8_value(data, TYPE_DYNAMIC_NETWORK)) {
+        PRINTF("Invalid STRUCTURE_TYPE value\n");
+        return false;
+    }
+    return true;
 }
 
 /**
@@ -53,7 +57,11 @@ static bool handle_struct_type(const tlv_data_t *data, s_network_info_ctx *conte
  */
 static bool handle_struct_version(const tlv_data_t *data, s_network_info_ctx *context) {
     UNUSED(context);
-    return tlv_check_struct_version(data, NETWORK_STRUCT_VERSION);
+    if (!tlv_enforce_u8_value(data, NETWORK_STRUCT_VERSION)) {
+        PRINTF("Invalid STRUCTURE_VERSION value\n");
+        return false;
+    }
+    return true;
 }
 
 /**
@@ -65,7 +73,7 @@ static bool handle_struct_version(const tlv_data_t *data, s_network_info_ctx *co
  */
 static bool handle_blockchain_family(const tlv_data_t *data, s_network_info_ctx *context) {
     UNUSED(context);
-    if (!tlv_check_uint8(data, BLOCKCHAIN_FAMILY_ETHEREUM)) {
+    if (!tlv_enforce_u8_value(data, BLOCKCHAIN_FAMILY_ETHEREUM)) {
         PRINTF("BLOCKCHAIN_FAMILY: error\n");
         return false;
     }

--- a/src/features/provide_network_info/network_info.c
+++ b/src/features/provide_network_info/network_info.c
@@ -130,7 +130,7 @@ static bool handle_icon_hash(const tlv_data_t *data, s_network_info_ctx *context
     if (!tlv_get_hash(data, context->icon_hash, sizeof(context->icon_hash))) {
         return false;
     }
-    if (allzeroes(context->icon_hash, CX_SHA256_SIZE) == 1) {
+    if (is_zeroes_buffer(context->icon_hash, CX_SHA256_SIZE)) {
         PRINTF("NETWORK_ICON_HASH: all zeroes\n");
         return false;
     }
@@ -320,7 +320,7 @@ static bool append_network_info(const s_network_info_ctx *context) {
  */
 static bool prepare_network_icon(const s_network_info_ctx *context) {
     // Check if the icon hash is provided
-    if (allzeroes(context->icon_hash, CX_SHA256_SIZE) == 1) {
+    if (is_zeroes_buffer(context->icon_hash, CX_SHA256_SIZE)) {
         PRINTF("/!\\ Icon hash is not provided!\n");
         return true;
     }

--- a/src/features/provide_proxy_info/proxy_info.c
+++ b/src/features/provide_proxy_info/proxy_info.c
@@ -29,7 +29,11 @@ static s_proxy_info *g_proxy_info = NULL;
  */
 static bool handle_struct_type(const tlv_data_t *data, s_proxy_info_ctx *context) {
     UNUSED(context);
-    return tlv_check_struct_type(data, TYPE_PROXY_INFO);
+    if (!tlv_enforce_u8_value(data, TYPE_PROXY_INFO)) {
+        PRINTF("Invalid STRUCTURE_TYPE value\n");
+        return false;
+    }
+    return true;
 }
 
 /**
@@ -41,7 +45,11 @@ static bool handle_struct_type(const tlv_data_t *data, s_proxy_info_ctx *context
  */
 static bool handle_struct_version(const tlv_data_t *data, s_proxy_info_ctx *context) {
     UNUSED(context);
-    return tlv_check_struct_version(data, STRUCT_VERSION);
+    if (!tlv_enforce_u8_value(data, STRUCT_VERSION)) {
+        PRINTF("Invalid STRUCT_VERSION value\n");
+        return false;
+    }
+    return true;
 }
 
 /**

--- a/src/features/provide_safe_account/cmd_safe_account.c
+++ b/src/features/provide_safe_account/cmd_safe_account.c
@@ -63,7 +63,7 @@ uint16_t handle_safe_account(uint8_t p1, uint8_t p2, const uint8_t *data, uint8_
     // Display UI when all data is received
     if (SIGNER_DESC.is_valid) {
         ui_display_safe_account();
-        return APDU_NO_RESPONSE;
+        return SWO_NO_RESPONSE;
     }
     return SWO_SUCCESS;
 }

--- a/src/features/provide_safe_account/safe_descriptor.c
+++ b/src/features/provide_safe_account/safe_descriptor.c
@@ -73,7 +73,7 @@ static bool handle_address(const tlv_data_t *data, s_safe_ctx *context) {
     if (!tlv_get_address(data, (uint8_t *) context->safe->address)) {
         return false;
     }
-    if (allzeroes(context->safe->address, ADDRESS_LENGTH) == 1) {
+    if (is_zeroes_buffer(context->safe->address, ADDRESS_LENGTH)) {
         PRINTF("ADDRESS: all zeroes\n");
         return false;
     }

--- a/src/features/provide_safe_account/safe_descriptor.c
+++ b/src/features/provide_safe_account/safe_descriptor.c
@@ -35,7 +35,11 @@ safe_descriptor_t *SAFE_DESC = NULL;
  */
 static bool handle_struct_type(const tlv_data_t *data, s_safe_ctx *context) {
     UNUSED(context);
-    return tlv_check_struct_type(data, TYPE_LESM_ACCOUNT_INFO);
+    if (!tlv_enforce_u8_value(data, TYPE_LESM_ACCOUNT_INFO)) {
+        PRINTF("Invalid STRUCTURE_TYPE value\n");
+        return false;
+    }
+    return true;
 }
 
 /**
@@ -47,7 +51,11 @@ static bool handle_struct_type(const tlv_data_t *data, s_safe_ctx *context) {
  */
 static bool handle_struct_version(const tlv_data_t *data, s_safe_ctx *context) {
     UNUSED(context);
-    return tlv_check_struct_version(data, STRUCT_VERSION);
+    if (!tlv_enforce_u8_value(data, STRUCT_VERSION)) {
+        PRINTF("Invalid STRUCTURE_VERSION value\n");
+        return false;
+    }
+    return true;
 }
 
 /**

--- a/src/features/provide_safe_account/signer_descriptor.c
+++ b/src/features/provide_safe_account/signer_descriptor.c
@@ -79,7 +79,7 @@ static bool handle_address(const tlv_data_t *data, s_signer_ctx *context) {
                          (uint8_t *) context->signers->data[context->address_count].address)) {
         return false;
     }
-    if (allzeroes(context->signers->data[context->address_count].address, ADDRESS_LENGTH) == 1) {
+    if (is_zeroes_buffer(context->signers->data[context->address_count].address, ADDRESS_LENGTH)) {
         PRINTF("ADDRESS: all zeroes\n");
         return false;
     }

--- a/src/features/provide_safe_account/signer_descriptor.c
+++ b/src/features/provide_safe_account/signer_descriptor.c
@@ -34,7 +34,11 @@ signers_descriptor_t SIGNER_DESC = {0};
  */
 static bool handle_struct_type(const tlv_data_t *data, s_signer_ctx *context) {
     UNUSED(context);
-    return tlv_check_struct_type(data, TYPE_VERIFIABLE_ADDRESS);
+    if (!tlv_enforce_u8_value(data, TYPE_VERIFIABLE_ADDRESS)) {
+        PRINTF("Invalid STRUCTURE_TYPE value\n");
+        return false;
+    }
+    return true;
 }
 
 /**
@@ -46,7 +50,11 @@ static bool handle_struct_type(const tlv_data_t *data, s_signer_ctx *context) {
  */
 static bool handle_struct_version(const tlv_data_t *data, s_signer_ctx *context) {
     UNUSED(context);
-    return tlv_check_struct_version(data, STRUCT_VERSION);
+    if (!tlv_enforce_u8_value(data, STRUCT_VERSION)) {
+        PRINTF("Invalid STRUCTURE_VERSION value\n");
+        return false;
+    }
+    return true;
 }
 
 /**

--- a/src/features/provide_trusted_name/trusted_name.c
+++ b/src/features/provide_trusted_name/trusted_name.c
@@ -120,7 +120,11 @@ const s_trusted_name *get_trusted_name(uint8_t type_count,
  */
 static bool handle_struct_type(const tlv_data_t *data, s_trusted_name_ctx *context) {
     UNUSED(context);
-    return tlv_check_struct_type(data, STRUCT_TYPE_TRUSTED_NAME);
+    if (!tlv_enforce_u8_value(data, STRUCT_TYPE_TRUSTED_NAME)) {
+        PRINTF("Invalid STRUCTURE_TYPE value\n");
+        return false;
+    }
+    return true;
 }
 
 /**
@@ -227,7 +231,10 @@ static bool handle_signer_algo(const tlv_data_t *data, s_trusted_name_ctx *conte
         PRINTF("SIGNER_ALGO: failed to extract\n");
         return false;
     }
-    CHECK_FIELD_VALUE("SIGNER_ALGO", value, SIG_ALGO_SECP256K1);
+    if (value != SIG_ALGO_SECP256K1) {
+        PRINTF("SIGNER_ALGO Value mismatch!\n");
+        return false;
+    }
     return true;
 }
 

--- a/src/features/provide_tx_simulation/cmd_get_tx_simulation.c
+++ b/src/features/provide_tx_simulation/cmd_get_tx_simulation.c
@@ -475,7 +475,7 @@ uint16_t handle_tx_simulation(uint8_t p1, uint8_t p2, const uint8_t *data, uint8
         case 0x01:
             // TX Simulation Opt-In
             handle_tx_simulation_opt_in(true);
-            sw = APDU_NO_RESPONSE;
+            sw = SWO_NO_RESPONSE;
             break;
         default:
             PRINTF("Error: Unexpected P1 (%u)!\n", p1);

--- a/src/features/provide_tx_simulation/cmd_get_tx_simulation.c
+++ b/src/features/provide_tx_simulation/cmd_get_tx_simulation.c
@@ -64,7 +64,7 @@ static bool parse_tx_hash(const tlv_data_t *data, s_tx_simu_ctx *context) {
     if (!tlv_get_hash(data, (uint8_t *) context->simu->tx_hash, sizeof(context->simu->tx_hash))) {
         return false;
     }
-    if (allzeroes(context->simu->tx_hash, HASH_SIZE) == 1) {
+    if (is_zeroes_buffer(context->simu->tx_hash, HASH_SIZE)) {
         PRINTF("TX_HASH: all zeroes\n");
         return false;
     }
@@ -84,7 +84,7 @@ static bool parse_domain_hash(const tlv_data_t *data, s_tx_simu_ctx *context) {
                       sizeof(context->simu->domain_hash))) {
         return false;
     }
-    if (allzeroes(context->simu->domain_hash, HASH_SIZE) == 1) {
+    if (is_zeroes_buffer(context->simu->domain_hash, HASH_SIZE)) {
         PRINTF("DOMAIN_HASH: all zeroes\n");
         return false;
     }
@@ -102,7 +102,7 @@ static bool parse_address(const tlv_data_t *data, s_tx_simu_ctx *context) {
     if (!tlv_get_address(data, (uint8_t *) context->simu->address)) {
         return false;
     }
-    if (allzeroes(context->simu->address, ADDRESS_LENGTH) == 1) {
+    if (is_zeroes_buffer(context->simu->address, ADDRESS_LENGTH)) {
         PRINTF("ADDRESS: all zeroes\n");
         return false;
     }

--- a/src/features/provide_tx_simulation/cmd_get_tx_simulation.c
+++ b/src/features/provide_tx_simulation/cmd_get_tx_simulation.c
@@ -38,7 +38,11 @@ tx_simulation_t TX_SIMULATION = {0};
  */
 static bool parse_struct_type(const tlv_data_t *data, s_tx_simu_ctx *context) {
     UNUSED(context);
-    return tlv_check_struct_type(data, TYPE_TX_SIMULATION);
+    if (!tlv_enforce_u8_value(data, TYPE_TX_SIMULATION)) {
+        PRINTF("Invalid STRUCTURE_TYPE value\n");
+        return false;
+    }
+    return true;
 }
 
 /**
@@ -50,7 +54,11 @@ static bool parse_struct_type(const tlv_data_t *data, s_tx_simu_ctx *context) {
  */
 static bool parse_struct_version(const tlv_data_t *data, s_tx_simu_ctx *context) {
     UNUSED(context);
-    return tlv_check_struct_version(data, STRUCT_VERSION);
+    if (!tlv_enforce_u8_value(data, STRUCT_VERSION)) {
+        PRINTF("Invalid STRUCTURE_VERSION value\n");
+        return false;
+    }
+    return true;
 }
 
 /**

--- a/src/features/sign_authorization_eip7702/auth_7702.c
+++ b/src/features/sign_authorization_eip7702/auth_7702.c
@@ -13,7 +13,11 @@
  */
 static bool handle_version(const tlv_data_t *data, s_auth_7702_ctx *context) {
     UNUSED(context);
-    return tlv_check_struct_version(data, STRUCT_VERSION);
+    if (!tlv_enforce_u8_value(data, STRUCT_VERSION)) {
+        PRINTF("Invalid STRUCTURE_VERSION value\n");
+        return false;
+    }
+    return true;
 }
 
 /**

--- a/src/features/sign_authorization_eip7702/commands_7702.c
+++ b/src/features/sign_authorization_eip7702/commands_7702.c
@@ -139,7 +139,7 @@ static bool handle_auth7702_tlv(const buffer_t *buf) {
                                    NULL,
                                    auth7702->chainId));
     // * Delegate
-    if (!allzeroes(auth7702->delegate, sizeof(auth7702->delegate))) {
+    if (!is_zeroes_buffer(auth7702->delegate, sizeof(auth7702->delegate))) {
         // Check if the delegate is on the whitelist for this chainId
         delegateName = get_delegate_name(&auth7702->chainId, auth7702->delegate);
         if (delegateName == NULL) {
@@ -172,7 +172,7 @@ static bool handle_auth7702_tlv(const buffer_t *buf) {
         }
     }
 
-    if (allzeroes(auth7702->delegate, sizeof(auth7702->delegate))) {
+    if (is_zeroes_buffer(auth7702->delegate, sizeof(auth7702->delegate))) {
         ui_sign_7702_revocation();
     } else {
         ui_sign_7702_auth();

--- a/src/features/sign_authorization_eip7702/commands_7702.c
+++ b/src/features/sign_authorization_eip7702/commands_7702.c
@@ -29,7 +29,7 @@ cx_sha3_t *g_7702_hash_ctx = NULL;
  * @param [in] dataLength size of the parameter to hash
  * @param [out] rlpTmp temporary buffer to store the RLP encoded parameter
  * @param [in] rlpTmpLength size of the temporary buffer to store the RLP encoded parameter
- * @return APDU_NO_RESPONSE if the parameter could be hashed, or an error code
+ * @return SWO_NO_RESPONSE if the parameter could be hashed, or an error code
  */
 uint16_t hashRLP(const uint8_t *data, uint8_t dataLength, uint8_t *rlpTmp, uint8_t rlpTmpLength) {
     cx_err_t error = CX_INTERNAL_ERROR;
@@ -40,7 +40,7 @@ uint16_t hashRLP(const uint8_t *data, uint8_t dataLength, uint8_t *rlpTmp, uint8
         return SWO_PARAMETER_ERROR_NO_INFO;
     }
     CX_CHECK(cx_hash_no_throw((cx_hash_t *) g_7702_hash_ctx, 0, rlpTmp, hashSize, NULL, 0));
-    return APDU_NO_RESPONSE;
+    return SWO_NO_RESPONSE;
 end:
     return error;
 }
@@ -50,7 +50,7 @@ end:
  * @param [in] data uint64_t to hash
  * @param [out] rlpTmp temporary buffer to store the RLP encoded parameter
  * @param [in] rlpTmpLength size of the temporary buffer to store the RLP encoded parameter
- * @return APDU_NO_RESPONSE if the parameter could be hashed, or an error code
+ * @return SWO_NO_RESPONSE if the parameter could be hashed, or an error code
  */
 uint16_t hash_RLP64(uint64_t data, uint8_t *rlpTmp, uint8_t rlpTmpLength) {
     uint8_t tmp[8];
@@ -110,17 +110,17 @@ static bool handle_auth7702_tlv(const buffer_t *buf) {
     CX_CHECK(cx_keccak_init_no_throw(g_7702_hash_ctx, 256));
     CX_CHECK(cx_hash_no_throw((cx_hash_t *) g_7702_hash_ctx, 0, rlpTmp, hashSize + 1, NULL, 0));
     sw = hash_RLP64(auth7702->chainId, rlpTmp, sizeof(rlpTmp));
-    if (sw != APDU_NO_RESPONSE) {
+    if (sw != SWO_NO_RESPONSE) {
         g_7702_sw = sw;
         goto end;
     }
     sw = hashRLP(auth7702->delegate, sizeof(auth7702->delegate), rlpTmp, sizeof(rlpTmp));
-    if (sw != APDU_NO_RESPONSE) {
+    if (sw != SWO_NO_RESPONSE) {
         g_7702_sw = sw;
         goto end;
     }
     sw = hash_RLP64(auth7702->nonce, rlpTmp, sizeof(rlpTmp));
-    if (sw != APDU_NO_RESPONSE) {
+    if (sw != SWO_NO_RESPONSE) {
         g_7702_sw = sw;
         goto end;
     }
@@ -198,5 +198,5 @@ uint16_t handle_sign_eip7702_authorization(uint8_t p1,
     if (!tlv_from_apdu(p1 == P1_FIRST_CHUNK, dataLength, dataBuffer, &handle_auth7702_tlv)) {
         return g_7702_sw;
     }
-    return APDU_NO_RESPONSE;
+    return SWO_NO_RESPONSE;
 }

--- a/src/features/sign_message/cmd_sign_message.c
+++ b/src/features/sign_message/cmd_sign_message.c
@@ -277,7 +277,7 @@ uint16_t handle_sign_personal_message(uint8_t p1, const uint8_t *const payload, 
             return sw;
         }
         ui_191_start(signMsgCtx->display_buffer);
-        return APDU_NO_RESPONSE;
+        return SWO_NO_RESPONSE;
     }
     return SWO_SUCCESS;
 }

--- a/src/features/sign_message_eip712/commands_712.c
+++ b/src/features/sign_message_eip712/commands_712.c
@@ -274,10 +274,10 @@ uint16_t handle_eip712_sign(const uint8_t *cdata, uint8_t length) {
         apdu_response_code = SWO_COMMAND_NOT_ALLOWED;
     }
     // if the final hashes are still zero or if there are some unimplemented fields
-    else if (allzeroes(tmpCtx.messageSigningContext712.domainHash,
-                       sizeof(tmpCtx.messageSigningContext712.domainHash)) ||
-             allzeroes(tmpCtx.messageSigningContext712.messageHash,
-                       sizeof(tmpCtx.messageSigningContext712.messageHash)) ||
+    else if (is_zeroes_buffer(tmpCtx.messageSigningContext712.domainHash,
+                              sizeof(tmpCtx.messageSigningContext712.domainHash)) ||
+             is_zeroes_buffer(tmpCtx.messageSigningContext712.messageHash,
+                              sizeof(tmpCtx.messageSigningContext712.messageHash)) ||
              (path_get_field() != NULL)) {
         apdu_response_code = SWO_INCORRECT_DATA;
     } else if ((ui_712_get_filtering_mode() == EIP712_FILTERING_FULL) &&

--- a/src/features/sign_message_eip712/commands_712.c
+++ b/src/features/sign_message_eip712/commands_712.c
@@ -167,7 +167,7 @@ uint16_t handle_eip712_struct_impl(uint8_t p1, uint8_t p2, const uint8_t *cdata,
         apdu_reply(ret);
         return apdu_response_code;
     }
-    return APDU_NO_RESPONSE;
+    return SWO_NO_RESPONSE;
 }
 
 /**
@@ -258,7 +258,7 @@ uint16_t handle_eip712_filtering(uint8_t p1, uint8_t p2, const uint8_t *cdata, u
         apdu_reply(ret);
         return apdu_response_code;
     }
-    return APDU_NO_RESPONSE;
+    return SWO_NO_RESPONSE;
 }
 
 /**
@@ -303,5 +303,5 @@ uint16_t handle_eip712_sign(const uint8_t *cdata, uint8_t length) {
         apdu_reply(false);
         return apdu_response_code;
     }
-    return APDU_NO_RESPONSE;
+    return SWO_NO_RESPONSE;
 }

--- a/src/features/sign_message_eip712_v0/cmd_sign_message_eip712.c
+++ b/src/features/sign_message_eip712_v0/cmd_sign_message_eip712.c
@@ -31,5 +31,5 @@ uint16_t handle_sign_eip712_message_v0(uint8_t p1, const uint8_t *workBuffer, ui
         return sw;
     }
 
-    return APDU_NO_RESPONSE;
+    return SWO_NO_RESPONSE;
 }

--- a/src/features/sign_tx/cmd_sign_tx.c
+++ b/src/features/sign_tx/cmd_sign_tx.c
@@ -74,11 +74,11 @@ static uint16_t handle_first_sign_chunk(const uint8_t *payload,
         txContext.txType = LEGACY;
     }
     PRINTF("TxType: %x\n", txContext.txType);
-    return APDU_NO_RESPONSE;
+    return SWO_NO_RESPONSE;
 }
 
 uint16_t handle_parsing_status(parserStatus_e status) {
-    uint16_t sw = APDU_NO_RESPONSE;
+    uint16_t sw = SWO_NO_RESPONSE;
 
     switch (status) {
         case USTREAM_SUSPENDED:
@@ -110,7 +110,7 @@ uint16_t handle_parsing_status(parserStatus_e status) {
 }
 
 uint16_t handle_sign(uint8_t p1, uint8_t p2, const uint8_t *payload, uint8_t length) {
-    uint16_t sw = APDU_NO_RESPONSE;
+    uint16_t sw = SWO_NO_RESPONSE;
     uint8_t offset = 0;
 
     switch (p2) {
@@ -119,7 +119,7 @@ uint16_t handle_sign(uint8_t p1, uint8_t p2, const uint8_t *payload, uint8_t len
             switch (p1) {
                 case P1_FIRST:
                     if ((sw = handle_first_sign_chunk(payload, length, &offset, p2)) !=
-                        APDU_NO_RESPONSE) {
+                        SWO_NO_RESPONSE) {
                         return sw;
                     }
                     break;
@@ -159,7 +159,7 @@ uint16_t handle_sign(uint8_t p1, uint8_t p2, const uint8_t *payload, uint8_t len
                 ui_gcs_cleanup();
                 return SWO_NOT_SUPPORTED_ERROR_NO_INFO;
             }
-            return APDU_NO_RESPONSE;
+            return SWO_NO_RESPONSE;
         default:
             return SWO_WRONG_P1_P2;
     }
@@ -173,10 +173,10 @@ uint16_t handle_sign(uint8_t p1, uint8_t p2, const uint8_t *payload, uint8_t len
     if (p2 == SIGN_MODE_BASIC) {
         if ((pstatus == USTREAM_FINISHED) && (sw == SWO_SUCCESS)) {
             // don't respond now, will be done after review
-            sw = APDU_NO_RESPONSE;
+            sw = SWO_NO_RESPONSE;
         }
     }
-    if (sw != APDU_NO_RESPONSE) {
+    if (sw != SWO_NO_RESPONSE) {
         if ((sw != SWO_SUCCESS) && (g_tx_hash_ctx != NULL)) {
             APP_MEM_FREE_AND_NULL((void **) &g_tx_hash_ctx);
         }

--- a/src/features/sign_tx/logic_sign_tx.c
+++ b/src/features/sign_tx/logic_sign_tx.c
@@ -288,7 +288,7 @@ __attribute__((noinline)) static uint16_t finalize_parsing_helper(const txContex
         if (g_chain_config->chain_id != chain_id) {
             PRINTF("Invalid chainID %llu expected %llu\n", chain_id, g_chain_config->chain_id);
             report_finalize_error();
-            return APDU_NO_RESPONSE;
+            return SWO_NO_RESPONSE;
         }
     }
     // Store the hash
@@ -328,7 +328,7 @@ __attribute__((noinline)) static uint16_t finalize_parsing_helper(const txContex
             ETH_PLUGIN_RESULT_SUCCESSFUL) {
             PRINTF("Plugin finalize call failed\n");
             report_finalize_error();
-            error = APDU_NO_RESPONSE;
+            error = SWO_NO_RESPONSE;
             goto end;
         }
 
@@ -357,7 +357,7 @@ __attribute__((noinline)) static uint16_t finalize_parsing_helper(const txContex
                 ETH_PLUGIN_RESULT_UNSUCCESSFUL) {
                 PRINTF("Plugin provide token call failed\n");
                 report_finalize_error();
-                error = APDU_NO_RESPONSE;
+                error = SWO_NO_RESPONSE;
                 goto end;
             }
             pluginFinalize.result = pluginProvideInfo.result;
@@ -380,7 +380,7 @@ __attribute__((noinline)) static uint16_t finalize_parsing_helper(const txContex
                 default:
                     PRINTF("ui type %d not supported\n", pluginFinalize.uiType);
                     report_finalize_error();
-                    error = APDU_NO_RESPONSE;
+                    error = SWO_NO_RESPONSE;
                     goto end;
             }
         } else if (G_called_from_swap && G_swap_mode == SWAP_MODE_CROSSCHAIN_SUCCESS) {
@@ -426,7 +426,7 @@ __attribute__((noinline)) static uint16_t finalize_parsing_helper(const txContex
             PRINTF("Data is present but not allowed\n");
             report_finalize_error();
             ui_error_blind_signing();
-            error = APDU_NO_RESPONSE;
+            error = SWO_NO_RESPONSE;
             goto end;
         }
     }

--- a/src/main.c
+++ b/src/main.c
@@ -166,7 +166,7 @@ const uint8_t *parseBip32(const uint8_t *dataBuffer, uint8_t *dataLength, bip32_
  * - Preserve existing state-reset and cleanup behavior when adding new cases.
  */
 static uint16_t handleApdu(command_t *cmd, uint32_t *tx) {
-    uint16_t sw = APDU_NO_RESPONSE;
+    uint16_t sw = SWO_NO_RESPONSE;
 
     if (cmd->cla != CLA) {
         return SWO_INVALID_CLA;
@@ -307,7 +307,7 @@ static uint16_t handleApdu(command_t *cmd, uint32_t *tx) {
 
 void app_main(void) {
     uint32_t tx = 0;
-    uint16_t sw = APDU_NO_RESPONSE;
+    uint16_t sw = SWO_NO_RESPONSE;
     command_t cmd = {0};
 
     // DESIGN NOTE: the bootloader ignores the way APDU are fetched. The only
@@ -354,7 +354,7 @@ void app_main(void) {
         }
         END_TRY;
 
-        if (sw == APDU_NO_RESPONSE) {
+        if (sw == SWO_NO_RESPONSE) {
             // Nothing to report
             continue;
         }

--- a/src/nbgl/ui_approve_tx.c
+++ b/src/nbgl/ui_approve_tx.c
@@ -127,7 +127,8 @@ static bool setTagValuePairs(bool displayNetwork, bool fromPlugin) {
         // Display the Amount
         // ------------------
         if (!tmpContent.txContent.dataPresent ||
-            !allzeroes(tmpContent.txContent.value.value, tmpContent.txContent.value.length)) {
+            !is_zeroes_buffer(tmpContent.txContent.value.value,
+                              tmpContent.txContent.value.length)) {
             g_pairs[nbPairs].item = "Amount";
             g_pairs[nbPairs].value = strings.common.fullAmount;
             nbPairs++;
@@ -239,7 +240,8 @@ static uint8_t getNbPairs(bool displayNetwork, bool fromPlugin) {
         }
         // Count the Amount
         if (!tmpContent.txContent.dataPresent ||
-            !allzeroes(tmpContent.txContent.value.value, tmpContent.txContent.value.length)) {
+            !is_zeroes_buffer(tmpContent.txContent.value.value,
+                              tmpContent.txContent.value.length)) {
             // This is not displayed if the amount is 0 and data is present
             nbPairs++;
         }

--- a/src/plugins/eip7002/eip7002_plugin.c
+++ b/src/plugins/eip7002/eip7002_plugin.c
@@ -66,7 +66,7 @@ static void eip7002_plugin_finalize(ethPluginFinalize_t *param) {
     eip7002_context_t *context = (eip7002_context_t *) param->pluginContext;
 
     param->uiType = ETH_UI_TYPE_GENERIC;
-    param->numScreens = allzeroes(context->raw_amount, sizeof(context->raw_amount)) ? 1 : 2;
+    param->numScreens = is_zeroes_buffer(context->raw_amount, sizeof(context->raw_amount)) ? 1 : 2;
     param->result = (context->received == sizeof(context->withdrawal_request))
                         ? ETH_PLUGIN_RESULT_OK
                         : ETH_PLUGIN_RESULT_ERROR;
@@ -76,7 +76,7 @@ static void eip7002_plugin_query_contract_id(ethQueryContractID_t *param) {
     eip7002_context_t *context = (eip7002_context_t *) param->pluginContext;
 
     strlcpy(param->version, "do", param->versionLength);
-    if (allzeroes(context->raw_amount, sizeof(context->raw_amount))) {
+    if (is_zeroes_buffer(context->raw_amount, sizeof(context->raw_amount))) {
         strlcpy(param->name, "full exit", param->nameLength);
     } else {
         strlcpy(param->name, "partial withdrawal", param->nameLength);

--- a/src/plugins/erc1155/erc1155_plugin.c
+++ b/src/plugins/erc1155/erc1155_plugin.c
@@ -69,7 +69,7 @@ void handle_finalize_1155(ethPluginFinalize_t *msg) {
             return;
     }
     // Check if some ETH is attached to this tx
-    if (!allzeroes((void *) &msg->txContent->value, sizeof(msg->txContent->value))) {
+    if (!is_zeroes_buffer((void *) &msg->txContent->value, sizeof(msg->txContent->value))) {
         // Those functions are not payable so return an error.
         msg->result = ETH_PLUGIN_RESULT_ERROR;
         return;

--- a/src/plugins/erc20/erc20_plugin.c
+++ b/src/plugins/erc20/erc20_plugin.c
@@ -43,7 +43,7 @@ void erc20_plugin_call(eth_plugin_msg_t message, void *parameters) {
             context->extra_data_len = 0;
 
             // enforce that ETH amount should be 0
-            if (!allzeroes(msg->txContent->value.value, CALLDATA_CHUNK_SIZE)) {
+            if (!is_zeroes_buffer(msg->txContent->value.value, CALLDATA_CHUNK_SIZE)) {
                 PRINTF("Err: Transaction amount is not 0\n");
                 msg->result = ETH_PLUGIN_RESULT_ERROR;
             } else {

--- a/src/plugins/erc20/erc20_plugin.c
+++ b/src/plugins/erc20/erc20_plugin.c
@@ -245,7 +245,7 @@ void erc20_plugin_call(eth_plugin_msg_t message, void *parameters) {
 
                     strlcpy(msg->title, "Extra Data", msg->titleLength);
 
-                    if (is_printable(context->extra_data, context->extra_data_len)) {
+                    if (is_printable_string(context->extra_data, context->extra_data_len)) {
                         // display as string
                         PRINTF("Display as ASCII string\n");
                         // should never trigger unless the msg->msg buffer has been downsized

--- a/src/plugins/erc721/erc721_plugin.c
+++ b/src/plugins/erc721/erc721_plugin.c
@@ -76,7 +76,7 @@ void handle_finalize_721(ethPluginFinalize_t *msg) {
             return;
     }
     // Check if some ETH is attached to this tx
-    if (!allzeroes((void *) &msg->txContent->value, sizeof(msg->txContent->value))) {
+    if (!is_zeroes_buffer((void *) &msg->txContent->value, sizeof(msg->txContent->value))) {
         // Set Approval for All is not payable
         if (context->selectorIndex == SET_APPROVAL_FOR_ALL) {
             msg->result = ETH_PLUGIN_RESULT_ERROR;

--- a/src/tlv_utils.c
+++ b/src/tlv_utils.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include "os_utils.h"
 #include "tlv_utils.h"
 #include "challenge.h"
 #include "common_utils.h"
@@ -158,7 +159,7 @@ bool tlv_get_printable_string(const tlv_data_t *data,
     }
     // Check if the name is printable
     // ('\0' is set by get_string_from_tlv_data, so we can use strlen safely)
-    if (!is_printable((const char *) out, strlen((const char *) out))) {
+    if (!is_printable_string((const char *) out, strlen((const char *) out))) {
         PRINTF("STRING is not printable!\n");
         return false;
     }

--- a/src/tlv_utils.c
+++ b/src/tlv_utils.c
@@ -7,40 +7,6 @@
 #include "utils.h"
 
 /**
- * @brief Parse and check the STRUCTURE_TYPE value.
- *
- * @param[in] data to handle
- * @param[in] expected value
- * @return whether the handling was successful
- */
-bool tlv_check_struct_type(const tlv_data_t *data, uint8_t expected) {
-    uint8_t value = 0;
-    if (!get_uint8_t_from_tlv_data(data, &value)) {
-        PRINTF("STRUCTURE_TYPE: failed to extract\n");
-        return false;
-    }
-    CHECK_FIELD_VALUE("STRUCTURE_TYPE", value, expected);
-    return true;
-}
-
-/**
- * @brief Parse and check the STRUCTURE_VERSION value.
- *
- * @param[in] data to handle
- * @param[in] expected value
- * @return whether the handling was successful
- */
-bool tlv_check_struct_version(const tlv_data_t *data, uint8_t expected) {
-    uint8_t value = 0;
-    if (!get_uint8_t_from_tlv_data(data, &value)) {
-        PRINTF("STRUCTURE_VERSION: failed to extract\n");
-        return false;
-    }
-    CHECK_FIELD_VALUE("STRUCTURE_VERSION", value, expected);
-    return true;
-}
-
-/**
  * @brief Parse and check the CHALLENGE value.
  *
  * @param[in] data to handle
@@ -228,25 +194,5 @@ bool tlv_get_uint8_range(const tlv_data_t *data, uint8_t *out, uint8_t min_val, 
         return false;
     }
     *out = value;
-    return true;
-}
-
-/**
- * @brief Parse and check an uint8_t value.
- *
- * @param[in] data to handle
- * @param[in] expected expected value
- * @return whether the handling was successful
- */
-bool tlv_check_uint8(const tlv_data_t *data, uint8_t expected) {
-    uint8_t value = 0;
-    if (!get_uint8_t_from_tlv_data(data, &value)) {
-        PRINTF("UINT8: failed to extract\n");
-        return false;
-    }
-    if (value != expected) {
-        PRINTF("UINT8: Value mismatch (%d /%d)!\n", value, expected);
-        return false;
-    }
     return true;
 }

--- a/src/tlv_utils.h
+++ b/src/tlv_utils.h
@@ -5,18 +5,7 @@
 #include "os_print.h"
 #include "tlv_library.h"
 
-// Macro to check the field value
-#define CHECK_FIELD_VALUE(tag, value, expected)  \
-    do {                                         \
-        if (value != expected) {                 \
-            PRINTF("%s Value mismatch!\n", tag); \
-            return false;                        \
-        }                                        \
-    } while (0)
-
 // Helper functions for common TLV parsing operations
-bool tlv_check_struct_type(const tlv_data_t *data, uint8_t expected);
-bool tlv_check_struct_version(const tlv_data_t *data, uint8_t expected);
 bool tlv_check_challenge(const tlv_data_t *data);
 bool tlv_get_chain_id(const tlv_data_t *data, uint64_t *chain_id);
 bool tlv_get_hash(const tlv_data_t *data, uint8_t *out, uint16_t max_size);
@@ -30,4 +19,3 @@ bool tlv_get_uint16_range(const tlv_data_t *data,
                           uint16_t min_val,
                           uint16_t max_val);
 bool tlv_get_uint8_range(const tlv_data_t *data, uint8_t *out, uint8_t min_val, uint8_t max_val);
-bool tlv_check_uint8(const tlv_data_t *data, uint8_t expected);

--- a/src/utils.c
+++ b/src/utils.c
@@ -61,24 +61,6 @@ void str_cpy_explicit_trunc(const char *src, size_t src_size, char *dst, size_t 
 }
 
 /**
- * @brief Checks if a string contains only printable ASCII characters
- *
- * This function determines if all characters in the provided string are within the
- * range of displayable ASCII characters (from 0x20 to 0x7E).
- *
- * @param[in] str A pointer to the string to be checked
- * @param[in] len The length of the string to be checked
- */
-bool is_printable(const char *str, size_t len) {
-    for (size_t i = 0; i < len; i++) {
-        if (isprint((int) str[i]) == 0) {
-            return false;
-        }
-    }
-    return true;
-}
-
-/**
  * @brief Reverses a string in place
  *
  * This function reverses the characters in the provided string.

--- a/src/utils.h
+++ b/src/utils.h
@@ -7,5 +7,4 @@
 
 void buf_shrink_expand(const uint8_t *src, size_t src_size, uint8_t *dst, size_t dst_size);
 void str_cpy_explicit_trunc(const char *src, size_t src_size, char *dst, size_t dst_size);
-bool is_printable(const char *str, size_t len);
 void reverseString(char *const str, uint32_t length);

--- a/tests/ragger/conftest.py
+++ b/tests/ragger/conftest.py
@@ -26,7 +26,7 @@ def pytest_configure(config):
 
 
 @pytest.fixture(name="app_version")
-def app_version_fixture(request) -> tuple[int, int, int]:
+def app_version_fixture() -> tuple[int, int, int]:
     with open(Path(__file__).parent.parent.parent / "Makefile", encoding="utf-8") as f:
         parsed = {}
         for m in re.findall(r"^APPVERSION_(\w)\s*=\s*(\d*)$", f.read(), re.MULTILINE):

--- a/tests/ragger/test_privacy_operation.py
+++ b/tests/ragger/test_privacy_operation.py
@@ -1,17 +1,13 @@
 import pytest
 
 from ragger.backend import BackendInterface
-from ragger.backend.speculos import SpeculosBackend
 
 from client.client import EthAppClient
 from client.status_word import StatusWord
 
 
-
+@pytest.mark.skip_on_backend("speculos")
 def test_perform_privacy_operation_public(backend: BackendInterface):
-
-    if isinstance(backend, SpeculosBackend):
-        pytest.skip("Not supported on speculos")
 
     app_client = EthAppClient(backend)
 
@@ -21,10 +17,8 @@ def test_perform_privacy_operation_public(backend: BackendInterface):
     print(f"Data: {response.data.hex()}")
 
 
+@pytest.mark.skip_on_backend("speculos")
 def test_perform_privacy_operation_secret(backend: BackendInterface):
-
-    if isinstance(backend, SpeculosBackend):
-        pytest.skip("Not supported on speculos")
 
     pubkey = "5901c19a086d1be4b907ec0325bffa758c3eb78192c3df4afa2afd2736a39963".encode("utf-8")
 

--- a/tests/ragger/test_tx_simulation.py
+++ b/tests/ragger/test_tx_simulation.py
@@ -13,7 +13,6 @@ from ragger.navigator.navigation_scenario import NavigateWithScenario
 from test_sign import common as sign_tx_common
 from test_blind_sign import test_blind_sign as blind_sign
 from test_nft import common_test_nft, collecs_721, actions_721, ERC721_PLUGIN
-from test_eip191 import common as sign_eip191
 from test_eip712 import test_eip712_filtering_empty_array as sign_eip712
 from test_eip712 import test_eip712_v0 as sign_eip712_v0
 from test_gcs import test_gcs_poap as sign_gcs_poap
@@ -238,36 +237,6 @@ def test_tx_simulation_blind_sign(scenario_navigator: NavigateWithScenario, conf
                False,
                0.0,
                simu_params)
-
-
-@pytest.mark.skip_nano
-def test_tx_simulation_eip191(scenario_navigator: NavigateWithScenario, config: str) -> None:
-    """Test the TX Simulation APDU with a Message Streaming based on EIP191"""
-
-    # TODO Re-activate when partners are ready for eip191
-    pytest.skip("Skip until partners are ready for eip191")
-
-    backend = scenario_navigator.backend
-    app_client = EthAppClient(backend)
-    device = backend.device
-
-    if config in ("benign", "warning"):
-        pytest.skip("Skipping useless tests")
-
-    __common_setting_handling(device, scenario_navigator.navigator, app_client, True)
-
-    test_name = scenario_navigator.test_name
-    simu_params = __get_simu_params(config, TxType.PERSONAL_MESSAGE)
-    msg = "Example `personal_sign` message with TX Simulation"
-    if config == "issue":
-        msg += " and wrong hash"
-        simu_params.tx_hash = bytes.fromhex("deadbeaf"*8)
-        test_name += f"_{config}"
-
-    sign_eip191(scenario_navigator,
-                test_name,
-                msg,
-                simu_params)
 
 
 @pytest.mark.skip_nano

--- a/tests/ragger/test_tx_simulation.py
+++ b/tests/ragger/test_tx_simulation.py
@@ -79,6 +79,7 @@ def __handle_simulation(app_client: EthAppClient, simu_params: TxSimu) -> None:
     assert response.status == StatusWord.OK
 
 
+@pytest.mark.skip_nano
 def test_tx_simulation_opt_in(backend: BackendInterface,
                               navigator: Navigator,
                               test_name: str,
@@ -86,9 +87,6 @@ def test_tx_simulation_opt_in(backend: BackendInterface,
     """Test the TX Simulation Opt-In feature."""
 
     app_client = EthAppClient(backend)
-    device = backend.device
-    if device.is_nano:
-        pytest.skip("Not yet supported on Nano")
 
     response = app_client.get_app_configuration()
     assert response.status == StatusWord.OK
@@ -105,6 +103,7 @@ def test_tx_simulation_opt_in(backend: BackendInterface,
     assert response.data[0] & mask == mask
 
 
+@pytest.mark.skip_nano
 def test_tx_simulation_disabled(backend: BackendInterface, navigator: Navigator) -> None:
     """Test the TX Simulation APDU with the TRANSACTION_CHECKS setting disabled.
         It should return an error
@@ -112,8 +111,6 @@ def test_tx_simulation_disabled(backend: BackendInterface, navigator: Navigator)
 
     app_client = EthAppClient(backend)
     device = backend.device
-    if device.is_nano:
-        pytest.skip("Not yet supported on Nano")
 
     __common_setting_handling(device, navigator, app_client, False)
 
@@ -127,14 +124,12 @@ def test_tx_simulation_disabled(backend: BackendInterface, navigator: Navigator)
         assert False  # An exception should have been raised
 
 
+@pytest.mark.skip_nano
 def test_tx_simulation_enabled(backend: BackendInterface, navigator: Navigator) -> None:
     """Test the TX Simulation APDU with the TRANSACTION_CHECKS setting enabled"""
 
     app_client = EthAppClient(backend)
     device = backend.device
-
-    if device.is_nano:
-        pytest.skip("Not yet supported on Nano")
 
     __common_setting_handling(device, navigator, app_client, True)
 
@@ -143,15 +138,13 @@ def test_tx_simulation_enabled(backend: BackendInterface, navigator: Navigator) 
     __handle_simulation(app_client, simu_params)
 
 
+@pytest.mark.skip_nano
 def test_tx_simulation_sign(scenario_navigator: NavigateWithScenario, config: str) -> None:
     """Test the TX Simulation APDU with a simple transaction"""
 
     backend = scenario_navigator.backend
     app_client = EthAppClient(backend)
     device = backend.device
-
-    if device.is_nano:
-        pytest.skip("Not yet supported on Nano")
 
     __common_setting_handling(device, scenario_navigator.navigator, app_client, True)
 
@@ -176,6 +169,7 @@ def test_tx_simulation_sign(scenario_navigator: NavigateWithScenario, config: st
                    with_simu=config not in ("benign", "issue"))
 
 
+@pytest.mark.skip_nano
 def test_tx_simulation_no_simu(scenario_navigator: NavigateWithScenario) -> None:
     """Test the TX Transaction APDU without TX Simulation APDU
         but with the TRANSACTION_CHECKS setting enabled"""
@@ -183,9 +177,6 @@ def test_tx_simulation_no_simu(scenario_navigator: NavigateWithScenario) -> None
     backend = scenario_navigator.backend
     app_client = EthAppClient(backend)
     device = backend.device
-
-    if device.is_nano:
-        pytest.skip("Not yet supported on Nano")
 
     __common_setting_handling(device, scenario_navigator.navigator, app_client, True)
 
@@ -204,15 +195,13 @@ def test_tx_simulation_no_simu(scenario_navigator: NavigateWithScenario) -> None
                    with_simu=False)
 
 
+@pytest.mark.skip_nano
 def test_tx_simulation_nft(scenario_navigator: NavigateWithScenario) -> None:
     """Test the TX Simulation APDU with a Plugin & NFT transaction"""
 
     backend = scenario_navigator.backend
     app_client = EthAppClient(backend)
     device = backend.device
-
-    if device.is_nano:
-        pytest.skip("Not yet supported on Nano")
 
     __common_setting_handling(device, scenario_navigator.navigator, app_client, True)
 
@@ -227,6 +216,7 @@ def test_tx_simulation_nft(scenario_navigator: NavigateWithScenario) -> None:
                     simu_params)
 
 
+@pytest.mark.skip_nano
 def test_tx_simulation_blind_sign(scenario_navigator: NavigateWithScenario, config: str) -> None:
     """Test the TX Simulation APDU with a Blind Sign transaction"""
 
@@ -234,9 +224,6 @@ def test_tx_simulation_blind_sign(scenario_navigator: NavigateWithScenario, conf
     navigator = scenario_navigator.navigator
     app_client = EthAppClient(backend)
     device = backend.device
-
-    if device.is_nano:
-        pytest.skip("Not yet supported on Nano")
 
     __common_setting_handling(device, navigator, app_client, True)
 
@@ -253,6 +240,7 @@ def test_tx_simulation_blind_sign(scenario_navigator: NavigateWithScenario, conf
                simu_params)
 
 
+@pytest.mark.skip_nano
 def test_tx_simulation_eip191(scenario_navigator: NavigateWithScenario, config: str) -> None:
     """Test the TX Simulation APDU with a Message Streaming based on EIP191"""
 
@@ -263,8 +251,6 @@ def test_tx_simulation_eip191(scenario_navigator: NavigateWithScenario, config: 
     app_client = EthAppClient(backend)
     device = backend.device
 
-    if device.is_nano:
-        pytest.skip("Not yet supported on Nano")
     if config in ("benign", "warning"):
         pytest.skip("Skipping useless tests")
 
@@ -284,13 +270,11 @@ def test_tx_simulation_eip191(scenario_navigator: NavigateWithScenario, config: 
                 simu_params)
 
 
+@pytest.mark.skip_nano
 def test_tx_simulation_eip712(scenario_navigator: NavigateWithScenario) -> None:
     """Test the TX Simulation APDU with a Message Streaming based on EIP712"""
 
     app_client = EthAppClient(scenario_navigator.backend)
-
-    if scenario_navigator.backend.device.is_nano:
-        pytest.skip("Not yet supported on Nano")
 
     __common_setting_handling(scenario_navigator.backend.device, scenario_navigator.navigator, app_client, True)
 
@@ -299,13 +283,11 @@ def test_tx_simulation_eip712(scenario_navigator: NavigateWithScenario) -> None:
     sign_eip712(scenario_navigator, simu_params)
 
 
+@pytest.mark.skip_nano
 def test_tx_simulation_eip712_v0(scenario_navigator: NavigateWithScenario) -> None:
     """Test the TX Simulation APDU with a Message Streaming based on EIP712_v0"""
 
     app_client = EthAppClient(scenario_navigator.backend)
-
-    if scenario_navigator.backend.device.is_nano:
-        pytest.skip("Not yet supported on Nano")
 
     __common_setting_handling(scenario_navigator.backend.device, scenario_navigator.navigator, app_client, True)
 
@@ -314,6 +296,7 @@ def test_tx_simulation_eip712_v0(scenario_navigator: NavigateWithScenario) -> No
     sign_eip712_v0(scenario_navigator, simu_params)
 
 
+@pytest.mark.skip_nano
 def test_tx_simulation_gcs(navigator: Navigator,
                            scenario_navigator: NavigateWithScenario) -> None:
     """Test the TX Simulation APDU with a Message Streaming based on EIP712"""
@@ -322,9 +305,6 @@ def test_tx_simulation_gcs(navigator: Navigator,
     app_client = EthAppClient(backend)
     device = backend.device
 
-    if device.is_nano:
-        pytest.skip("Not yet supported on Nano")
-
     __common_setting_handling(device, navigator, app_client, True)
 
     simu_params = __get_simu_params("warning", TxType.TRANSACTION)
@@ -332,6 +312,7 @@ def test_tx_simulation_gcs(navigator: Navigator,
     sign_gcs_poap(scenario_navigator, simu_params)
 
 
+@pytest.mark.skip_nano
 def test_tx_simulation_provider_max_bounds(backend: BackendInterface,
                                            navigator: Navigator) -> None:
     """
@@ -341,9 +322,6 @@ def test_tx_simulation_provider_max_bounds(backend: BackendInterface,
 
     app_client = EthAppClient(backend)
     device = backend.device
-
-    if device.is_nano:
-        pytest.skip("Not yet supported on Nano")
 
     __common_setting_handling(device, navigator, app_client, True)
 

--- a/tests/unit/mocks/mock.c
+++ b/tests/unit/mocks/mock.c
@@ -12,6 +12,15 @@ void *pic(void *addr) {
     return addr;
 }
 
+bool is_printable_string(const char *str, size_t len) {
+    for (size_t i = 0; i < len; ++i) {
+        if (str[i] < 0x20 || str[i] > 0x7E) {
+            return false;
+        }
+    }
+    return true;
+}
+
 void assert_exit(bool confirm) {
     (void) confirm;
 }


### PR DESCRIPTION
## Description

- Cleanup tests with `markers` instead of `pytest.skip`
- Cleanup useless test
- Use SDK functions 'is_printable_string' directly
- Use SDK functions 'is_zeroes_buffer' directly
- Use directly 'SWO_NO_RESPONSE' from SDK
- Use directly 'tlv_enforce_u8_value' from SDK'

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
