### PR TITLE
CWE-451

### DIFF
--- a/src/features/generic_tx_parser/gtp_param_trusted_name.c
+++ b/src/features/generic_tx_parser/gtp_param_trusted_name.c
@@ -226,11 +226,10 @@ bool format_param_trusted_name(const struct s_field *field) {
                 break;
             case PARAM_VISIBILITY_IF_NOT_IN:
                 // Field is displayed only if value is NOT in the constraint list
-                ret = check_address_constraint(field, &values, i, addr);
-                if (ret) {
+                if (check_address_constraint(field, &values, i, addr)) {
                     PRINTF("Warning: TRUSTED_NAME does match a IF_NOT_IN constraint!\n");
-                    // Skip displaying the field
-                    goto cleanup;
+                    // Skip displaying only this value, continue with remaining values
+                    continue;
                 }
                 to_be_displayed = true;
                 break;


### PR DESCRIPTION
## Summary

Automated security fix for **IF_NOT_IN on multi-value TRUSTED_NAME fields suppresses all subsequent values** (High).

**CWE**: CWE-CWE-451
**OWASP**: A04:2021-Insecure Design
**Fix Confidence**: high

## What Changed
Replaced `goto cleanup` with `continue` in the PARAM_VISIBILITY_IF_NOT_IN branch so that a match only suppresses display of the current value in the collection instead of aborting the entire loop. Also removed the assignment to `ret` inside the IF_NOT_IN branch (its return value is used purely as a local branching decision now), which preserves `ret == true` from the prior successful iteration so `if (!ret) break;` on the next iteration behaves correctly and the overall function still returns success when all values are filtered out.

## Caveats
- If all values match IF_NOT_IN constraints, no fields are added to the table and the function returns true (same behavior as the original `goto cleanup` path which returned the then-true `ret`).
- The IF_NOT_IN branch no longer assigns to `ret`; this keeps `ret == true` across continues, which is the correct semantic since check_address_constraint is purely a visibility filter, not a success/failure signal.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
