### PR TITLE
Fix new compilation warning

### DIFF
--- a/src/features/sign_message_eip712/ui_logic.c
+++ b/src/features/sign_message_eip712/ui_logic.c
@@ -347,7 +347,7 @@ bool ui_712_message_hash(void) {
  * @param[in] length its length
  * @param[in] last if this is the last chunk
  */
-static void ui_712_format_str(const uint8_t *data, uint8_t length, bool last) {
+static void ui_712_format_str(const uint8_t *data, size_t length, bool last) {
     size_t max_len = sizeof(strings.tmp.tmp) - 1;
     size_t cur_len = strlen(strings.tmp.tmp);
     size_t available;


### PR DESCRIPTION
## Description

New with LLVM 21.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)