### PR TITLE
removing strcasecmp_workaround following newlib update

### DIFF
--- a/src/swap/eth_swap_utils.c
+++ b/src/swap/eth_swap_utils.c
@@ -195,29 +195,6 @@ void get_asset_info_on_network(bool is_fee,
 }
 
 /**
- * Local implementation of strcasecmp, workaround for the segfaulting base implementation
- * on return value. Remove once strcasecmp is fixed.
- *
- * @param str1 First string to compare
- * @param str2 Second string to compare
- * @return 0 if strings are equal (case-insensitive), difference otherwise
- */
-static int strcasecmp_workaround(const char *str1, const char *str2) {
-    unsigned char c1, c2;
-
-    LEDGER_ASSERT(str1 != NULL, "strcasecmp_workaround: str1 is NULL");
-    LEDGER_ASSERT(str2 != NULL, "strcasecmp_workaround: str2 is NULL");
-    do {
-        c1 = *str1++;
-        c2 = *str2++;
-        if (toupper(c1) != toupper(c2)) {
-            return toupper(c1) - toupper(c2);
-        }
-    } while (c1 != '\0');
-    return 0;
-}
-
-/**
  * Verify that the destination address matches the previously validated one
  *
  * @param destination Destination address to verify
@@ -228,7 +205,7 @@ bool swap_check_destination(const char *destination) {
         return false;
     }
     // Ensure the values are the same that the ones that have been previously validated
-    if (strcasecmp_workaround(strings.common.toAddress, destination) != 0) {
+    if (strcasecmp(strings.common.toAddress, destination) != 0) {
         PRINTF("Error comparing destination addresses\n");
         send_swap_error_with_string(APDU_RESPONSE_MODE_CHECK_FAILED,
                                     SWAP_EC_ERROR_WRONG_DESTINATION,


### PR DESCRIPTION
## Description

removing strcasecmp_workaround following newlib update.
Related to https://github.com/LedgerHQ/ledger-secure-sdk/pull/1592, which needs to be merged first.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
