### PR TITLE
Reject empty hash in tlv_get_hash

### DIFF
--- a/src/utils/tlv_utils.c
+++ b/src/utils/tlv_utils.c
@@ -54,30 +54,24 @@ bool tlv_get_chain_id(const tlv_data_t *data, uint64_t *chain_id) {
  *
  * @param[in] data to handle
  * @param[out] out buffer to store the hash
- * @param[in] max_size of the hash
+ * @param[in] size exact expected size of the hash
  * @return whether the handling was successful
  */
-bool tlv_get_hash(const tlv_data_t *data, uint8_t *out, uint16_t max_size) {
+bool tlv_get_hash(const tlv_data_t *data, uint8_t *out, uint16_t size) {
     buffer_t hash = {0};
     if (!out) {
         PRINTF("HASH: null pointer provided\n");
         return false;
     }
-    if (!max_size) {
+    if (!size) {
         PRINTF("HASH: invalid size\n");
         return false;
     }
-    if (!get_buffer_from_tlv_data(data, &hash, 0, max_size)) {
+    if (!get_buffer_from_tlv_data(data, &hash, size, size)) {
         PRINTF("HASH: failed to extract\n");
         return false;
     }
-    if (hash.size > 0) {
-        if (hash.ptr == NULL) {
-            PRINTF("HASH: null value\n");
-            return false;
-        }
-        memmove((void *) out, hash.ptr, hash.size);
-    }
+    memmove((void *) out, hash.ptr, hash.size);
     return true;
 }
 

--- a/src/utils/tlv_utils.h
+++ b/src/utils/tlv_utils.h
@@ -8,7 +8,7 @@
 // Helper functions for common TLV parsing operations
 bool tlv_check_challenge(const tlv_data_t *data);
 bool tlv_get_chain_id(const tlv_data_t *data, uint64_t *chain_id);
-bool tlv_get_hash(const tlv_data_t *data, uint8_t *out, uint16_t max_size);
+bool tlv_get_hash(const tlv_data_t *data, uint8_t *out, uint16_t size);
 bool tlv_get_address(const tlv_data_t *data, uint8_t *out);
 bool tlv_get_printable_string(const tlv_data_t *data,
                               char *out,

--- a/tests/unit/src/test_tlv_utils.c
+++ b/tests/unit/src/test_tlv_utils.c
@@ -116,10 +116,10 @@ static void test_get_hash_happy(void **state) {
     (void) state;
     uint8_t bytes[4] = {0xDE, 0xAD, 0xBE, 0xEF};
     tlv_data_t d = make_tlv(bytes, sizeof(bytes));
-    uint8_t out[16] = {0};
+    uint8_t out[4] = {0};
     assert_true(tlv_get_hash(&d, out, sizeof(out)));
     static const uint8_t expected[4] = {0xDE, 0xAD, 0xBE, 0xEF};
-    assert_memory_equal(out, expected, 4);
+    assert_memory_equal(out, expected, sizeof(expected));
 }
 
 static void test_get_hash_null_out_rejected(void **state) {


### PR DESCRIPTION

## Description

Fix to prevent use of uninitialized memory

When hash.size == 0 after TLV extraction, the memmove was skipped but the function still returned true, leaving the caller's output buffer uninitialized. Detected by MemorySanitizer via ClusterFuzzLite in handle_selector.


## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)